### PR TITLE
Corrected BytesToString function output

### DIFF
--- a/Camelotia.Presentation.Tests/LocalFileSystemProviderTests.cs
+++ b/Camelotia.Presentation.Tests/LocalFileSystemProviderTests.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Threading.Tasks;
+using Camelotia.Services.Models;
 using Camelotia.Services.Interfaces;
 using Camelotia.Services.Providers;
 using FluentAssertions;
@@ -33,6 +34,29 @@ namespace Camelotia.Services.Tests
                     model.IsFolder == File
                         .GetAttributes(path)
                         .HasFlag(FileAttributes.Directory));
+        }
+        [Theory]
+        [InlineData(0, "0B")]
+        [InlineData(520400, "520.4KB")]
+        [InlineData(520040000, "520MB")]
+        [InlineData(520068000, "520.1MB")]
+        [InlineData(520185000000, "520.2GB")]
+        public void ByteConverterShouldCalculateWithNoPrecisionSupplied(long byteCount, string expectedValue)
+        {
+            var stringValue = ByteConverter.BytesToString(byteCount);
+            stringValue.Should().Be(expectedValue);
+        }
+        [Theory]
+        [InlineData(115, 1, "115B")]
+        [InlineData(115, 3, "115B")]
+        [InlineData(520348, 3, "520.348KB")]
+        [InlineData(520462400, 3, "520.462MB")]
+        [InlineData(520573990000, 3, "520.574GB")]
+        [InlineData(520124960000, 3, "520.125GB")]
+        public void ByteConverterShouldCalculate(long byteCount, int precision, string expectedValue)
+        {
+            var stringValue = ByteConverter.BytesToString(byteCount, precision);
+            stringValue.Should().Be(expectedValue);
         }
     }
 }

--- a/Camelotia.Services/Models/ByteConverter.cs
+++ b/Camelotia.Services/Models/ByteConverter.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Camelotia.Services.Models
+{
+    public static class ByteConverter
+    {
+        public static string BytesToString(long byteCount, int decimalPrecision = 1)
+        {
+            string[] suf = { "B", "KB", "MB", "GB", "TB", "PB", "EB" };
+            if (byteCount == 0)
+                return "0" + suf[0];
+
+            var bytes = Math.Abs(byteCount);
+            var place = Convert.ToInt32(Math.Floor(Math.Log(bytes, 1000)));
+            var num = Math.Round(bytes / Math.Pow(1000, place), decimalPrecision);
+            return (Math.Sign(byteCount) * num) + suf[place];
+        }
+    }
+}

--- a/Camelotia.Services/Providers/LocalFileSystemProvider.cs
+++ b/Camelotia.Services/Providers/LocalFileSystemProvider.cs
@@ -36,7 +36,7 @@ namespace Camelotia.Services.Providers
             
             var query = from entity in Directory.GetFileSystemEntries(path) 
                         let isDirectory = IsDirectory(entity) 
-                        let size = isDirectory ? "*" : BytesToString(new FileInfo(entity).Length) 
+                        let size = isDirectory ? "*" : ByteConverter.BytesToString(new FileInfo(entity).Length) 
                         select new FileModel(Path.GetFileName(entity), entity, isDirectory, size);
 
             return query
@@ -82,19 +82,7 @@ namespace Camelotia.Services.Providers
                 .Select(x => x.AvailableFreeSpace)
                 .Sum();
             
-            return BytesToString(totalBytes);
-        }
-        
-        private static string BytesToString(long byteCount)
-        {
-            string[] suf = { "B", "KB", "MB", "GB", "TB", "PB", "EB" };
-            if (byteCount == 0)
-                return "0" + suf[0];
-            
-            var bytes = Math.Abs(byteCount);
-            var place = Convert.ToInt32(Math.Floor(Math.Log(bytes, 1024)));
-            var num = Math.Round(bytes / Math.Pow(1024, place), 1);
-            return (Math.Sign(byteCount) * num) + suf[place];
+            return ByteConverter.BytesToString(totalBytes);
         }
 
         private static bool IsDirectory(string path)

--- a/Camelotia.Services/Providers/VkontakteFileSystemProvider.cs
+++ b/Camelotia.Services/Providers/VkontakteFileSystemProvider.cs
@@ -68,7 +68,7 @@ namespace Camelotia.Services.Providers
             {
                 var size = string.Empty;
                 if (document.Size.HasValue)
-                    size = BytesToString(document.Size.Value);
+                    size = ByteConverter.BytesToString(document.Size.Value);
                 return new FileModel(document.Title, document.Uri, false, size);
             });
         }
@@ -132,18 +132,6 @@ namespace Camelotia.Services.Providers
             }
         }
 
-        private static string BytesToString(long byteCount)
-        {
-            string[] suf = { "B", "KB", "MB", "GB", "TB", "PB", "EB" };
-            if (byteCount == 0)
-                return "0" + suf[0];
-            
-            var bytes = Math.Abs(byteCount);
-            var place = Convert.ToInt32(Math.Floor(Math.Log(bytes, 1024)));
-            var num = Math.Round(bytes / Math.Pow(1024, place), 1);
-            return (Math.Sign(byteCount) * num) + suf[place];
-        }
-        
         internal class DocUploadResponse
         {
             [JsonProperty("file")]


### PR DESCRIPTION
Fixed math error should be 1000 not 1024 when converting from bytes to kilobytes and beyond.  Extracted method to new class to remove two redundant functions in filesystem classes.  Added tests to LocalFileSystemProviderTests, it could go to a seperate test class, if you prefer.

Used: google byte converter to create test cases.

1024 is used to convert from binary digits.  