### PR TITLE
GetSizeOnAllDisks throws exception on LocalFileSystem

### DIFF
--- a/Camelotia.Services/Providers/LocalFileSystemProvider.cs
+++ b/Camelotia.Services/Providers/LocalFileSystemProvider.cs
@@ -79,6 +79,7 @@ namespace Camelotia.Services.Providers
         {
             var totalBytes = DriveInfo
                 .GetDrives()
+                .Where(p => p.DriveType != DriveType.CDRom)
                 .Select(x => x.AvailableFreeSpace)
                 .Sum();
             


### PR DESCRIPTION
Dvd/Cd will throw exception: System.IO.IOException: 'The device is not ready'.