### PR TITLE
LocalFileSystemProvider now starts at Drive View.

### DIFF
--- a/Camelotia.Presentation.Tests/LocalFileSystemProviderTests.cs
+++ b/Camelotia.Presentation.Tests/LocalFileSystemProviderTests.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Camelotia.Services.Interfaces;
 using Camelotia.Services.Providers;
@@ -33,6 +34,19 @@ namespace Camelotia.Presentation.Tests
                     model.IsFolder == File
                         .GetAttributes(path)
                         .HasFlag(FileAttributes.Directory));
+        }
+        [Fact]
+        public async Task ShouldReturnDrivesFromAnEmptyPath()
+        {
+            var real = await _provider.Get(_provider.InitialPath);
+            var expected = DriveInfo
+                            .GetDrives()
+                            .Where(p => p.DriveType != DriveType.CDRom);
+            foreach (var model in real)
+                expected.Should().Contain(drive =>
+                    model.Name == drive.Name &&
+                    model.IsFolder == false
+                    && model.IsDrive == true);
         }
     }
 }

--- a/Camelotia.Presentation.Tests/ProviderViewModelTests.cs
+++ b/Camelotia.Presentation.Tests/ProviderViewModelTests.cs
@@ -93,7 +93,7 @@ namespace Camelotia.Presentation.Tests
         [Fact]
         public void ShouldBeAbleToOpenSelectedPath() => new TestScheduler().With(scheduler =>
         {
-            var file = new FileModel("foo", Separator + "foo", true, string.Empty);
+            var file = new FileModel("foo", Separator + "foo", true, false, string.Empty);
             _provider.Get(Separator).Returns(Enumerable.Repeat(file, 1));
             _authViewModel.IsAuthenticated.Returns(true);
 

--- a/Camelotia.Services/Interfaces/IProvider.cs
+++ b/Camelotia.Services/Interfaces/IProvider.cs
@@ -14,6 +14,8 @@ namespace Camelotia.Services.Interfaces
         
         string Description { get; }
 
+        string InitialPath { get; }
+
         Task<IEnumerable<FileModel>> Get(string path);
         
         Task UploadFile(string to, Stream from, string name);

--- a/Camelotia.Services/Models/FileModel.cs
+++ b/Camelotia.Services/Models/FileModel.cs
@@ -2,20 +2,22 @@ namespace Camelotia.Services.Models
 {
     public sealed class FileModel
     {
-        public FileModel(string name, string path, bool isFolder, string size)
+        public FileModel(string name, string path, bool isFolder, bool isDrive, string size)
         {
             Name = name;
             Path = path;
-            Size = size;
             IsFolder = isFolder;
+            IsDrive = isDrive;
+            Size = size;
         }
-        
-        public bool IsFolder { get; }
-        
         public string Name { get; }
-        
+
         public string Path { get; }
-        
+
+        public bool IsFolder { get; }
+
+        public bool IsDrive { get; }
+       
         public string Size { get; }
     }
 }

--- a/Camelotia.Services/Providers/LocalFileSystemProvider.cs
+++ b/Camelotia.Services/Providers/LocalFileSystemProvider.cs
@@ -23,6 +23,8 @@ namespace Camelotia.Services.Providers
         
         public bool SupportsOAuth => false;
 
+        public string InitialPath => string.Empty;
+
         public Task OAuth() => Task.CompletedTask;
 
         public Task Logout() => Task.CompletedTask;
@@ -31,13 +33,23 @@ namespace Camelotia.Services.Providers
 
         public Task<IEnumerable<FileModel>> Get(string path) => Task.Run(() =>
         {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                var driveQuery = from entity in GetAllDrives()
+                            let size = ByteConverter.BytesToString(entity.AvailableFreeSpace)
+                            select new FileModel(entity.Name, entity.Name, false, true, size);
+                return driveQuery
+                        .ToList()
+                        .AsEnumerable();
+            }
+            
             if (!Directory.Exists(path))
                 throw new ArgumentException("Directory doesn't exist.");
             
             var query = from entity in Directory.GetFileSystemEntries(path) 
                         let isDirectory = IsDirectory(entity) 
                         let size = isDirectory ? "*" : ByteConverter.BytesToString(new FileInfo(entity).Length) 
-                        select new FileModel(Path.GetFileName(entity), entity, isDirectory, size);
+                        select new FileModel(Path.GetFileName(entity), entity, isDirectory, false, size);
 
             return query
                 .ToList()
@@ -77,18 +89,26 @@ namespace Camelotia.Services.Providers
 
         private static string GetSizeOnAllDisks()
         {
-            var totalBytes = DriveInfo
-                .GetDrives()
-                .Where(p => p.DriveType != DriveType.CDRom)
+            var totalBytes = GetAllDrives()
                 .Select(x => x.AvailableFreeSpace)
                 .Sum();
             
             return ByteConverter.BytesToString(totalBytes);
         }
 
+        private static IEnumerable<DriveInfo> GetAllDrives()
+        {
+            var drives = DriveInfo
+                .GetDrives()
+                .Where(p => p.DriveType != DriveType.CDRom);
+
+            return drives;
+        }
+
         private static bool IsDirectory(string path)
         {
             var attributes = File.GetAttributes(path);
+
             return attributes.HasFlag(FileAttributes.Directory);
         }
     }

--- a/Camelotia.Services/Providers/VkontakteFileSystemProvider.cs
+++ b/Camelotia.Services/Providers/VkontakteFileSystemProvider.cs
@@ -40,6 +40,8 @@ namespace Camelotia.Services.Providers
 
         public bool SupportsOAuth => false;
 
+        public string InitialPath => Path.DirectorySeparatorChar.ToString();
+
         public Task OAuth() => Task.CompletedTask;
 
         public async Task DirectAuth(string login, string password)
@@ -74,7 +76,7 @@ namespace Camelotia.Services.Providers
                 var size = string.Empty;
                 if (document.Size.HasValue)
                     size = ByteConverter.BytesToString(document.Size.Value);
-                return new FileModel(document.Title, document.Uri, false, size);
+                return new FileModel(document.Title, document.Uri, false, false, size);
             });
         }
 

--- a/Camelotia.Services/Providers/YandexFileSystemProvider.cs
+++ b/Camelotia.Services/Providers/YandexFileSystemProvider.cs
@@ -38,7 +38,9 @@ namespace Camelotia.Services.Providers
         public bool SupportsDirectAuth => false;
 
         public bool SupportsOAuth => true;
-        
+
+        public string InitialPath => Path.DirectorySeparatorChar.ToString();
+
         public Task DirectAuth(string login, string password) => Task.CompletedTask;
         
         public async Task<IEnumerable<FileModel>> Get(string path)
@@ -59,6 +61,7 @@ namespace Camelotia.Services.Providers
                         file.Name,
                         file.Path.Replace("disk:", ""),
                         file.Type == "dir",
+                        false,
                         ByteConverter.BytesToString(file.Size)));
 
                 return models;


### PR DESCRIPTION
IProvider.InitialPath is added to the interface and each provider can implement its root location.  For LocalFileSystemProvider that allows for drives to be explored.  Two Tests are failing in the ProviderViewModelTests:
ShouldBeAbleToOpenSelectedPath
ShouldDisplayCurrentPathProperly
These tests no longer have the same logic as the seperator is no longer used in the LocalFileSystemProvider.  We need to discuss how to handle this change.