### PR TITLE
Refactor initial path changes

### DIFF
--- a/Camelotia.Presentation.Tests/LocalFileSystemProviderTests.cs
+++ b/Camelotia.Presentation.Tests/LocalFileSystemProviderTests.cs
@@ -51,5 +51,12 @@ namespace Camelotia.Presentation.Tests
                     model.IsFolder == false && 
                     model.IsDrive);
         }
+
+        [Fact]
+        public void ShouldImplementNonNullInitialPath()
+        {
+            _provider.InitialPath.Should().NotBeNull();
+        }
+   
     }
 }

--- a/Camelotia.Presentation.Tests/VkontakteFileSystemProviderTests.cs
+++ b/Camelotia.Presentation.Tests/VkontakteFileSystemProviderTests.cs
@@ -1,0 +1,18 @@
+﻿using Camelotia.Services.Interfaces;
+using Camelotia.Services.Providers;
+using FluentAssertions;
+using Xunit;
+
+namespace Camelotia.Presentation.Tests
+{
+    public sealed class VkontakteFileSystemProviderTests
+    {
+        private readonly IProvider _provider = new VkontakteFileSystemProvider();
+
+        [Fact]
+        public void ShouldImplementNonNullInitialPath()
+        {
+            _provider.InitialPath.Should().NotBeNull();
+        }
+    }
+}

--- a/Camelotia.Presentation.Tests/YandexFileSystemProviderTests.cs
+++ b/Camelotia.Presentation.Tests/YandexFileSystemProviderTests.cs
@@ -1,0 +1,18 @@
+﻿using Camelotia.Services.Interfaces;
+using Camelotia.Services.Providers;
+using FluentAssertions;
+using Xunit;
+
+namespace Camelotia.Presentation.Tests
+{
+    public sealed class YandexFileSystemProviderTests
+    {
+        private readonly IProvider _provider = new YandexFileSystemProvider();
+
+        [Fact]
+        public void ShouldImplementNonNullInitialPath()
+        {
+            _provider.InitialPath.Should().NotBeNull();
+        }
+    }
+}

--- a/Camelotia.Presentation/ViewModels/ProviderViewModel.cs
+++ b/Camelotia.Presentation/ViewModels/ProviderViewModel.cs
@@ -70,12 +70,12 @@ namespace Camelotia.Presentation.ViewModels
                 .CombineLatest(_refresh.IsExecuting, (folder, busy) => folder && !busy);
             
             _open = ReactiveCommand.Create(
-                () => Path.Combine(CurrentPath ?? string.Empty, SelectedFile.Name),
+                () => Path.Combine(CurrentPath, SelectedFile.Name),
                 canOpenCurrentPath, mainThread);
 
             var canCurrentPathGoBack = this
                 .WhenAnyValue(x => x.CurrentPath)
-                .Select(path => path?.Length > provider.InitialPath.Length)
+                .Select(path => path.Length > provider.InitialPath.Length)
                 .CombineLatest(_refresh.IsExecuting, (valid, busy) => valid && !busy);
             
             _back = ReactiveCommand.Create(
@@ -184,7 +184,7 @@ namespace Camelotia.Presentation.ViewModels
 
         public string Description => _provider.Description;
         
-        public string CurrentPath => _currentPath?.Value;
+        public string CurrentPath => _currentPath?.Value ?? _provider.InitialPath;
         
         public bool CanLogout => _canLogout.Value;
         


### PR DESCRIPTION
This is implementing the suggestion you made to implement: `public string CurrentPath => _currentPath?.Value ?? _provider.InitialPath;`

This is a big improvement and now pushes the null of CurrentPath to the implementation of IProvider.InitialPath.
Added Tests for all IProvider implementations that validate that InitialPath is not null.