### PR TITLE
Add ReactiveUI.Events packages

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
   steps:
   - task: DotNetCoreInstaller@0
     inputs:
-      version: '2.2.203'
+      version: '3.1.302'
   - script: cd $(Build.SourcesDirectory) && powershell -ExecutionPolicy Unrestricted ./build.ps1 --full
     displayName: 'Windows Full Build and Tests'
   - task: PublishTestResults@2

--- a/build/build.csproj
+++ b/build/build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <RootNamespace />
     <IsPackable>False</IsPackable>

--- a/src/Camelotia.Presentation.Avalonia/Camelotia.Presentation.Avalonia.csproj
+++ b/src/Camelotia.Presentation.Avalonia/Camelotia.Presentation.Avalonia.csproj
@@ -2,8 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>latest</LangVersion>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,6 +12,11 @@
     <PackageReference Include="Avalonia.Desktop" Version="0.9.10" />
     <PackageReference Include="Avalonia.ReactiveUI" Version="0.9.10" />
     <PackageReference Include="Citrus.Avalonia" Version="1.2.6" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Pharmacist.MsBuild" Version="1.8.1" PrivateAssets="all" />
+    <PackageReference Include="Pharmacist.Common" Version="1.8.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Camelotia.Presentation.Avalonia/Views/FileView.xaml.cs
+++ b/src/Camelotia.Presentation.Avalonia/Views/FileView.xaml.cs
@@ -3,7 +3,11 @@ using System.ComponentModel;
 using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.LogicalTree;
 using Avalonia.Markup.Xaml;
 using Avalonia.ReactiveUI;
 using Camelotia.Presentation.Interfaces;
@@ -15,24 +19,23 @@ namespace Camelotia.Presentation.Avalonia.Views
     {
         public FileView()
         {
+            AvaloniaXamlLoader.Load(this);
             this.WhenActivated(disposables =>
             {
-                Observable.FromEventPattern<CancelEventHandler, CancelEventArgs>(
-                        handler => ContextMenu.ContextMenuOpening += handler,
-                        handler => ContextMenu.ContextMenuOpening -= handler)
-                    .Do(args => args.EventArgs.Cancel = false)
-                    .Subscribe(args => ViewModel.Provider.SelectedFile = ViewModel)
-                    .DisposeWith(disposables);
-
-                Observable.FromEventPattern<RoutedEventArgs>(
-                        handler => DoubleTapped += handler,
-                        handler => DoubleTapped -= handler)
+                this.Events()
+                    .DoubleTapped
                     .Do(args => ViewModel.Provider.SelectedFile = ViewModel)
                     .Select(args => Unit.Default)
                     .InvokeCommand(this, x => x.ViewModel.Provider.Open)
                     .DisposeWith(disposables);
+
+                this.ContextMenu
+                    .Events()
+                    .ContextMenuOpening
+                    .Do(args => args.Cancel = false)
+                    .Subscribe(args => ViewModel.Provider.SelectedFile = ViewModel)
+                    .DisposeWith(disposables);
             });
-            AvaloniaXamlLoader.Load(this);
         }
     }
 }

--- a/src/Camelotia.Presentation.Uwp/Camelotia.Presentation.Uwp.csproj
+++ b/src/Camelotia.Presentation.Uwp/Camelotia.Presentation.Uwp.csproj
@@ -211,6 +211,9 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.10</Version>
     </PackageReference>
+    <PackageReference Include="ReactiveUI.Events">
+      <Version>11.4.17</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Camelotia.Presentation\Camelotia.Presentation.csproj">

--- a/src/Camelotia.Presentation.Uwp/Views/FileView.xaml.cs
+++ b/src/Camelotia.Presentation.Uwp/Views/FileView.xaml.cs
@@ -23,7 +23,7 @@ namespace Camelotia.Presentation.Uwp.Views
             {
                 this.Events()
                     .RightTapped
-                    .Select(args => (FileView) args.Sender)
+                    .Select(args => this)
                     .Do(sender => sender.ViewModel.Provider.SelectedFile = sender.ViewModel)
                     .Subscribe(FlyoutBase.ShowAttachedFlyout)
                     .DisposeWith(disposables);

--- a/src/Camelotia.Presentation.Uwp/Views/FileView.xaml.cs
+++ b/src/Camelotia.Presentation.Uwp/Views/FileView.xaml.cs
@@ -21,17 +21,15 @@ namespace Camelotia.Presentation.Uwp.Views
             InitializeComponent();
             this.WhenActivated(disposables =>
             {
-                Observable.FromEventPattern<RightTappedEventHandler, RightTappedRoutedEventArgs>(
-                        handler => RightTapped += handler,
-                        handler => RightTapped -= handler)
+                this.Events()
+                    .RightTapped
                     .Select(args => (FileView) args.Sender)
                     .Do(sender => sender.ViewModel.Provider.SelectedFile = sender.ViewModel)
                     .Subscribe(FlyoutBase.ShowAttachedFlyout)
                     .DisposeWith(disposables);
 
-                Observable.FromEventPattern<DoubleTappedEventHandler, DoubleTappedRoutedEventArgs>(
-                        handler => DoubleTapped += handler,
-                        handler => DoubleTapped -= handler)
+                this.Events()
+                    .DoubleTapped
                     .Select(args => Unit.Default)
                     .InvokeCommand(this, x => x.ViewModel.Provider.Open)
                     .DisposeWith(disposables);

--- a/src/Camelotia.Presentation.Xamarin/Camelotia.Presentation.Xamarin.csproj
+++ b/src/Camelotia.Presentation.Xamarin/Camelotia.Presentation.Xamarin.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="ReactiveUI.XamForms" Version="11.4.1" />
+    <PackageReference Include="ReactiveUI.Events.XamForms" Version="11.4.1" />
     <PackageReference Include="Xamarin.Forms" Version="4.6.0.800" />
     <PackageReference Include="Xam.Plugin.Iconize" Version="3.5.0.129" />
     <PackageReference Include="Xam.Plugin.Iconize.FontAwesome" Version="3.5.0.129" />

--- a/src/Camelotia.Presentation.Xamarin/Views/MainMasterView.xaml.cs
+++ b/src/Camelotia.Presentation.Xamarin/Views/MainMasterView.xaml.cs
@@ -45,9 +45,8 @@ namespace Camelotia.Presentation.Xamarin.Views
                 this.BindCommand(ViewModel, x => x.Add, x => x.AddButton)
                     .DisposeWith(disposables);
 
-                Observable.FromEventPattern<EventHandler, EventArgs>(
-                    x => OpenButton.Clicked += x,
-                    x => OpenButton.Clicked -= x)
+                this.OpenButton
+                    .Events().Clicked
                     .Select(args => ViewModel.SelectedProvider)
                     .Where(provider => provider != null)
                     .Select(x => new ProviderExplorerView { ViewModel = x })

--- a/src/Camelotia.Tests/Camelotia.Tests.csproj
+++ b/src/Camelotia.Tests/Camelotia.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+      <TargetFramework>netcoreapp3.1</TargetFramework>
+      <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>    


### PR DESCRIPTION
- Now we use `this.Events()` instead of writing `Observable.FromEventPattern` manually
- In the Avalonia app, we use `Pharmacist` to generate `Events()` at build time