### PR TITLE
Don't throw if appstate.json does not exist

### DIFF
--- a/src/Camelotia.Presentation/Infrastructure/NewtonsoftJsonSuspensionDriver.cs
+++ b/src/Camelotia.Presentation/Infrastructure/NewtonsoftJsonSuspensionDriver.cs
@@ -29,7 +29,11 @@ namespace Camelotia.Presentation.Infrastructure
         }
 
         public IObservable<object> LoadState()
-        {
+        {            
+            if (!File.Exists(_stateFilePath))
+            {
+                return Observable.Throw<object>(new FileNotFoundException(_stateFilePath));
+            }
             var lines = File.ReadAllText(_stateFilePath);
             var state = JsonConvert.DeserializeObject<object>(lines, _settings);
             return Observable.Return(state);


### PR DESCRIPTION
Currently `NewtonsoftJsonSuspensionDriver.LoadState()` throws a `FileNotFoundException` when appstate.json does not exist. 
This PR will fix that by returning and Observable that throws instead. ReactiveUI's SuspensionHost will create a new AppState in that case (see https://github.com/reactiveui/ReactiveUI/blob/a6c5dcf4f0ce82a9c0c8b05d7c78f80cd57028d1/src/ReactiveUI/Suspension/SuspensionHostExtensions.cs#L75)