### PR TITLE
Expose ReactiveCommand<TIn, TOut> instead of ICommand

### DIFF
--- a/src/Camelotia.Presentation.Avalonia/Views/ProviderView.xaml
+++ b/src/Camelotia.Presentation.Avalonia/Views/ProviderView.xaml
@@ -58,7 +58,7 @@
                 <DrawingPresenter Height="16" Drawing="{DynamicResource ArrowUp}"/>
               </Button>
                 <TextBlock Grid.Column="1"
-                           IsVisible="{Binding !ShowBreadCrumbs}"
+                           IsVisible="{Binding HideBreadCrumbs}"
                            Text="{Binding CurrentPath}"
                            VerticalAlignment="Center"
                            FontSize="14"

--- a/src/Camelotia.Presentation/DesignTime/DesignTimeCreateFolderViewModel.cs
+++ b/src/Camelotia.Presentation/DesignTime/DesignTimeCreateFolderViewModel.cs
@@ -1,5 +1,6 @@
-using System.Windows.Input;
+using System.Reactive;
 using Camelotia.Presentation.Interfaces;
+using ReactiveUI;
 using ReactiveUI.Validation.Extensions;
 using ReactiveUI.Validation.Helpers;
 
@@ -21,10 +22,10 @@ namespace Camelotia.Presentation.DesignTime
 
         public string ErrorMessage { get; } = "Error message example.";
         
-        public ICommand Create { get; }
+        public ReactiveCommand<Unit, Unit> Create { get; }
         
-        public ICommand Close { get; }
+        public ReactiveCommand<Unit, Unit> Close { get; }
         
-        public ICommand Open { get; }
+        public ReactiveCommand<Unit, Unit> Open { get; }
     }
 }

--- a/src/Camelotia.Presentation/DesignTime/DesignTimeDirectAuthViewModel.cs
+++ b/src/Camelotia.Presentation/DesignTime/DesignTimeDirectAuthViewModel.cs
@@ -1,5 +1,6 @@
-using System.Windows.Input;
+using System.Reactive;
 using Camelotia.Presentation.Interfaces;
+using ReactiveUI;
 using ReactiveUI.Validation.Extensions;
 using ReactiveUI.Validation.Helpers;
 
@@ -13,7 +14,7 @@ namespace Camelotia.Presentation.DesignTime
         
         public string Password { get; set; }
         
-        public ICommand Login { get; }
+        public ReactiveCommand<Unit, Unit> Login { get; }
 
         public bool HasErrorMessage { get; } = true;
 

--- a/src/Camelotia.Presentation/DesignTime/DesignTimeHostAuthViewModel.cs
+++ b/src/Camelotia.Presentation/DesignTime/DesignTimeHostAuthViewModel.cs
@@ -1,5 +1,6 @@
-using System.Windows.Input;
+using System.Reactive;
 using Camelotia.Presentation.Interfaces;
+using ReactiveUI;
 using ReactiveUI.Validation.Extensions;
 using ReactiveUI.Validation.Helpers;
 
@@ -13,7 +14,7 @@ namespace Camelotia.Presentation.DesignTime
 
         public string Password { get; set; } = "Qwerty";
         
-        public ICommand Login { get; }
+        public ReactiveCommand<Unit, Unit> Login { get; }
 
         public bool HasErrorMessage { get; } = true;
 

--- a/src/Camelotia.Presentation/DesignTime/DesignTimeMainViewModel.cs
+++ b/src/Camelotia.Presentation/DesignTime/DesignTimeMainViewModel.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Windows.Input;
+using System.Reactive;
 using Camelotia.Presentation.Interfaces;
 using Camelotia.Services.Models;
 using ReactiveUI;
@@ -28,13 +28,13 @@ namespace Camelotia.Presentation.DesignTime
         
         public bool WelcomeScreenVisible { get; }
         
-        public ICommand Unselect { get; }
+        public ReactiveCommand<Unit, Unit> Unselect { get; }
         
-        public ICommand Refresh { get; }
+        public ReactiveCommand<Unit, Unit> Refresh { get; }
         
-        public ICommand Remove { get; }
+        public ReactiveCommand<Unit, Unit> Remove { get; }
         
-        public ICommand Add { get; }
+        public ReactiveCommand<Unit, Unit> Add { get; }
         
         public bool IsLoading { get; }
 

--- a/src/Camelotia.Presentation/DesignTime/DesignTimeOAuthViewModel.cs
+++ b/src/Camelotia.Presentation/DesignTime/DesignTimeOAuthViewModel.cs
@@ -1,4 +1,4 @@
-using System.Windows.Input;
+using System.Reactive;
 using Camelotia.Presentation.Interfaces;
 using ReactiveUI;
 
@@ -6,7 +6,7 @@ namespace Camelotia.Presentation.DesignTime
 {
     public class DesignTimeOAuthViewModel : ReactiveObject, IOAuthViewModel
     {
-        public ICommand Login { get; }
+        public ReactiveCommand<Unit, Unit> Login { get; }
         
         public bool HasErrorMessage { get; } = true;
         

--- a/src/Camelotia.Presentation/DesignTime/DesignTimeProviderViewModel.cs
+++ b/src/Camelotia.Presentation/DesignTime/DesignTimeProviderViewModel.cs
@@ -64,6 +64,8 @@ namespace Camelotia.Presentation.DesignTime
 
         public bool ShowBreadCrumbs { get; } = true;
 
+        public bool HideBreadCrumbs { get; } = false;
+
         public int RefreshingIn { get; } = 30;
 
         public string CurrentPath { get; } = "/home/files";
@@ -72,22 +74,22 @@ namespace Camelotia.Presentation.DesignTime
         {
             new DesignTimeFolderViewModel 
             (
-                name: "home", 
-                children: new[] 
+                "home", 
+                new[] 
                 { 
-                    new DesignTimeFolderViewModel(name: "home"),
-                    new DesignTimeFolderViewModel(name: "home1"), 
-                    new DesignTimeFolderViewModel(name: "home2") 
+                    new DesignTimeFolderViewModel("home"),
+                    new DesignTimeFolderViewModel("home1"), 
+                    new DesignTimeFolderViewModel("home2") 
                 }
             ),
             new DesignTimeFolderViewModel
             (
-                name: "files",
-                children: new[]
+                "files",
+                new[]
                 {
-                    new DesignTimeFolderViewModel(name: "files"),
-                    new DesignTimeFolderViewModel(name: "files1"),
-                    new DesignTimeFolderViewModel(name: "files2")
+                    new DesignTimeFolderViewModel("files"),
+                    new DesignTimeFolderViewModel("files1"),
+                    new DesignTimeFolderViewModel("files2")
                 }
             )
         };

--- a/src/Camelotia.Presentation/DesignTime/DesignTimeProviderViewModel.cs
+++ b/src/Camelotia.Presentation/DesignTime/DesignTimeProviderViewModel.cs
@@ -1,8 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Windows.Input;
+using System.Reactive;
 using Camelotia.Presentation.Interfaces;
+using Camelotia.Services.Models;
 using ReactiveUI;
 
 namespace Camelotia.Presentation.DesignTime
@@ -31,23 +32,23 @@ namespace Camelotia.Presentation.DesignTime
 
         public IEnumerable<IFileViewModel> Files { get; }
 
-        public ICommand DownloadSelectedFile { get; }
+        public ReactiveCommand<Unit, Unit> DownloadSelectedFile { get; }
         
-        public ICommand UploadToCurrentPath { get; }
+        public ReactiveCommand<Unit, Unit> UploadToCurrentPath { get; }
         
-        public ICommand DeleteSelectedFile { get; }
+        public ReactiveCommand<Unit, Unit> DeleteSelectedFile { get; }
         
-        public ICommand UnselectFile { get; }
+        public ReactiveCommand<Unit, Unit> UnselectFile { get; }
         
-        public ICommand Refresh { get; }
+        public ReactiveCommand<Unit, IEnumerable<FileModel>> Refresh { get; }
         
-        public ICommand Logout { get; }
+        public ReactiveCommand<Unit, Unit> Logout { get; }
         
-        public ICommand Back { get; }
+        public ReactiveCommand<Unit, string> Back { get; }
         
-        public ICommand Open { get; }
+        public ReactiveCommand<Unit, string> Open { get; }
 
-        public ICommand SetPath { get; }
+        public ReactiveCommand<string, string> SetPath { get; }
 
         public bool IsCurrentPathEmpty { get; }
         

--- a/src/Camelotia.Presentation/DesignTime/DesignTimeRenameFileViewModel.cs
+++ b/src/Camelotia.Presentation/DesignTime/DesignTimeRenameFileViewModel.cs
@@ -1,5 +1,6 @@
-using System.Windows.Input;
+using System.Reactive;
 using Camelotia.Presentation.Interfaces;
+using ReactiveUI;
 using ReactiveUI.Validation.Extensions;
 using ReactiveUI.Validation.Helpers;
 
@@ -21,10 +22,10 @@ namespace Camelotia.Presentation.DesignTime
 
         public string ErrorMessage { get; } = "Error message example.";
         
-        public ICommand Rename { get; }
+        public ReactiveCommand<Unit, Unit> Rename { get; }
         
-        public ICommand Close { get; }
+        public ReactiveCommand<Unit, Unit> Close { get; }
         
-        public ICommand Open { get; }
+        public ReactiveCommand<Unit, Unit> Open { get; }
     }
 }

--- a/src/Camelotia.Presentation/Interfaces/ICreateFolderViewModel.cs
+++ b/src/Camelotia.Presentation/Interfaces/ICreateFolderViewModel.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
-using System.Windows.Input;
+using System.Reactive;
+using ReactiveUI;
 
 namespace Camelotia.Presentation.Interfaces
 {
@@ -17,10 +18,10 @@ namespace Camelotia.Presentation.Interfaces
         
         string ErrorMessage { get; }
         
-        ICommand Create { get; }
+        ReactiveCommand<Unit, Unit> Create { get; }
         
-        ICommand Close { get; }
+        ReactiveCommand<Unit, Unit> Close { get; }
         
-        ICommand Open { get; }
+        ReactiveCommand<Unit, Unit> Open { get; }
     }
 }

--- a/src/Camelotia.Presentation/Interfaces/IDirectAuthViewModel.cs
+++ b/src/Camelotia.Presentation/Interfaces/IDirectAuthViewModel.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
-using System.Windows.Input;
+using System.Reactive;
+using ReactiveUI;
 
 namespace Camelotia.Presentation.Interfaces
 {
@@ -9,7 +10,7 @@ namespace Camelotia.Presentation.Interfaces
         
         string Password { get; set; }
         
-        ICommand Login { get; }
+        ReactiveCommand<Unit, Unit> Login { get; }
         
         bool HasErrorMessage { get; }
         

--- a/src/Camelotia.Presentation/Interfaces/IMainViewModel.cs
+++ b/src/Camelotia.Presentation/Interfaces/IMainViewModel.cs
@@ -1,8 +1,9 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.Windows.Input;
+using System.Reactive;
 using Camelotia.Services.Models;
+using ReactiveUI;
 
 namespace Camelotia.Presentation.Interfaces
 {
@@ -20,13 +21,13 @@ namespace Camelotia.Presentation.Interfaces
 
         bool WelcomeScreenVisible { get; }
 
-        ICommand Unselect { get; }
+        ReactiveCommand<Unit, Unit> Unselect { get; }
 
-        ICommand Refresh { get; }
+        ReactiveCommand<Unit, Unit> Refresh { get; }
 
-        ICommand Remove { get; }
+        ReactiveCommand<Unit, Unit> Remove { get; }
 
-        ICommand Add { get; }
+        ReactiveCommand<Unit, Unit> Add { get; }
         
         bool IsLoading { get; }
         

--- a/src/Camelotia.Presentation/Interfaces/IOAuthViewModel.cs
+++ b/src/Camelotia.Presentation/Interfaces/IOAuthViewModel.cs
@@ -1,11 +1,12 @@
 using System.ComponentModel;
-using System.Windows.Input;
+using System.Reactive;
+using ReactiveUI;
 
 namespace Camelotia.Presentation.Interfaces
 {
     public interface IOAuthViewModel : INotifyPropertyChanged
     {
-        ICommand Login { get; }
+        ReactiveCommand<Unit, Unit> Login { get; }
         
         bool HasErrorMessage { get; }
         

--- a/src/Camelotia.Presentation/Interfaces/IProviderViewModel.cs
+++ b/src/Camelotia.Presentation/Interfaces/IProviderViewModel.cs
@@ -54,6 +54,8 @@ namespace Camelotia.Presentation.Interfaces
         bool CanInteract { get; }
 
         bool ShowBreadCrumbs { get; }
+        
+        bool HideBreadCrumbs { get; }
 
         int RefreshingIn { get; }
         

--- a/src/Camelotia.Presentation/Interfaces/IProviderViewModel.cs
+++ b/src/Camelotia.Presentation/Interfaces/IProviderViewModel.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Windows.Input;
+using System.Reactive;
+using Camelotia.Services.Models;
+using ReactiveUI;
 
 namespace Camelotia.Presentation.Interfaces
 {
@@ -21,23 +23,23 @@ namespace Camelotia.Presentation.Interfaces
 
         IEnumerable<IFolderViewModel> BreadCrumbs { get; }
 
-        ICommand DownloadSelectedFile { get; }
+        ReactiveCommand<Unit, Unit> DownloadSelectedFile { get; }
         
-        ICommand UploadToCurrentPath { get; }
+        ReactiveCommand<Unit, Unit> UploadToCurrentPath { get; }
 
-        ICommand DeleteSelectedFile { get; }
+        ReactiveCommand<Unit, Unit> DeleteSelectedFile { get; }
         
-        ICommand UnselectFile { get; }
+        ReactiveCommand<Unit, Unit> UnselectFile { get; }
 
-        ICommand Refresh { get; }
+        ReactiveCommand<Unit, IEnumerable<FileModel>> Refresh { get; }
         
-        ICommand Logout { get; }
+        ReactiveCommand<Unit, Unit> Logout { get; }
         
-        ICommand Back { get; }
+        ReactiveCommand<Unit, string> Back { get; }
         
-        ICommand Open { get; }
+        ReactiveCommand<Unit, string> Open { get; }
 
-        ICommand SetPath { get; }
+        ReactiveCommand<string, string> SetPath { get; }
 
         bool IsCurrentPathEmpty { get; }
         

--- a/src/Camelotia.Presentation/Interfaces/IRenameFileViewModel.cs
+++ b/src/Camelotia.Presentation/Interfaces/IRenameFileViewModel.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
-using System.Windows.Input;
+using System.Reactive;
+using ReactiveUI;
 
 namespace Camelotia.Presentation.Interfaces
 {
@@ -17,10 +18,10 @@ namespace Camelotia.Presentation.Interfaces
         
         string ErrorMessage { get; }
         
-        ICommand Rename { get; }
+        ReactiveCommand<Unit, Unit> Rename { get; }
         
-        ICommand Close { get; }
+        ReactiveCommand<Unit, Unit> Close { get; }
         
-        ICommand Open { get; }
+        ReactiveCommand<Unit, Unit> Open { get; }
     }
 }

--- a/src/Camelotia.Presentation/ViewModels/AuthViewModel.cs
+++ b/src/Camelotia.Presentation/ViewModels/AuthViewModel.cs
@@ -8,6 +8,8 @@ namespace Camelotia.Presentation.ViewModels
 {
     public sealed class AuthViewModel : ReactiveObject, IAuthViewModel
     {
+        private readonly ObservableAsPropertyHelper<bool> _isAuthenticated;
+        private readonly ObservableAsPropertyHelper<bool> _isAnonymous;
         private readonly IProvider _provider;
         
         public AuthViewModel(
@@ -21,22 +23,22 @@ namespace Camelotia.Presentation.ViewModels
             DirectAuth = direct;
             _provider = provider;
             
-            _provider.IsAuthorized
+            _isAuthenticated = _provider
+                .IsAuthorized
                 .DistinctUntilChanged()
                 .Log(this, $"Authentication state changed for {provider.Name}")
                 .ObserveOn(RxApp.MainThreadScheduler)
-                .ToPropertyEx(this, x => x.IsAuthenticated);
+                .ToProperty(this, x => x.IsAuthenticated);
 
-            this.WhenAnyValue(x => x.IsAuthenticated)
+            _isAnonymous = this
+                .WhenAnyValue(x => x.IsAuthenticated)
                 .Select(authenticated => !authenticated)
-                .ToPropertyEx(this, x => x.IsAnonymous);
+                .ToProperty(this, x => x.IsAnonymous);
         }
 
-        [ObservableAsProperty]
-        public bool IsAuthenticated { get; }
+        public bool IsAnonymous => _isAnonymous.Value;
 
-        [ObservableAsProperty]
-        public bool IsAnonymous { get; }
+        public bool IsAuthenticated => _isAuthenticated.Value;
 
         public bool SupportsDirectAuth => _provider.SupportsDirectAuth;
 

--- a/src/Camelotia.Presentation/ViewModels/CreateFolderViewModel.cs
+++ b/src/Camelotia.Presentation/ViewModels/CreateFolderViewModel.cs
@@ -17,7 +17,8 @@ namespace Camelotia.Presentation.ViewModels
     {
         public CreateFolderViewModel(CreateFolderState state, IProviderViewModel owner, IProvider provider)
         {
-            owner.WhenAnyValue(x => x.CurrentPath).ToPropertyEx(this, x => x.Path);
+            owner.WhenAnyValue(x => x.CurrentPath)
+                 .ToPropertyEx(this, x => x.Path);
             
             this.ValidationRule(x => x.Name,
                 name => !string.IsNullOrWhiteSpace(name),
@@ -72,10 +73,10 @@ namespace Camelotia.Presentation.ViewModels
                 .ToPropertyEx(this, x => x.ErrorMessage);
 
             Name = state.Name;
+            IsVisible = state.IsVisible;
+
             this.WhenAnyValue(x => x.Name)
                 .Subscribe(name => state.Name = name);
-
-            IsVisible = state.IsVisible;
             this.WhenAnyValue(x => x.IsVisible)
                 .Subscribe(visible => state.IsVisible = visible);
         }

--- a/src/Camelotia.Presentation/ViewModels/DirectAuthViewModel.cs
+++ b/src/Camelotia.Presentation/ViewModels/DirectAuthViewModel.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Reactive;
 using System.Reactive.Linq;
-using System.Windows.Input;
 using Camelotia.Presentation.AppState;
 using Camelotia.Presentation.Interfaces;
 using Camelotia.Services.Interfaces;
@@ -14,8 +13,6 @@ namespace Camelotia.Presentation.ViewModels
 {
     public sealed class DirectAuthViewModel : ReactiveValidationObject<DirectAuthViewModel>, IDirectAuthViewModel
     {
-        private readonly ReactiveCommand<Unit, Unit> _login;
-        
         public DirectAuthViewModel(DirectAuthState state, IProvider provider)
         {
             this.ValidationRule(x => x.Username,
@@ -26,20 +23,20 @@ namespace Camelotia.Presentation.ViewModels
                 pass => !string.IsNullOrWhiteSpace(pass),
                 "Password shouldn't be null or white space.");
             
-            _login = ReactiveCommand.CreateFromTask(
+            Login = ReactiveCommand.CreateFromTask(
                 () => provider.DirectAuth(Username, Password),
                 this.IsValid());
             
-            _login.IsExecuting.ToPropertyEx(this, x => x.IsBusy);
+            Login.IsExecuting.ToPropertyEx(this, x => x.IsBusy);
             
-            _login.ThrownExceptions
+            Login.ThrownExceptions
                 .Select(exception => exception.Message)
                 .Log(this, $"Direct auth error occured in {provider.Name}")
                 .ToPropertyEx(this, x => x.ErrorMessage);
 
-            _login.ThrownExceptions
+            Login.ThrownExceptions
                 .Select(exception => true)
-                .Merge(_login.Select(unit => false))
+                .Merge(Login.Select(unit => false))
                 .ToPropertyEx(this, x => x.HasErrorMessage);
 
             Username = state.Username;
@@ -66,6 +63,6 @@ namespace Camelotia.Presentation.ViewModels
         [ObservableAsProperty]
         public bool IsBusy { get; }
         
-        public ICommand Login => _login;
+        public ReactiveCommand<Unit, Unit> Login { get; }
     }
 }

--- a/src/Camelotia.Presentation/ViewModels/DirectAuthViewModel.cs
+++ b/src/Camelotia.Presentation/ViewModels/DirectAuthViewModel.cs
@@ -13,6 +13,10 @@ namespace Camelotia.Presentation.ViewModels
 {
     public sealed class DirectAuthViewModel : ReactiveValidationObject<DirectAuthViewModel>, IDirectAuthViewModel
     {
+        private readonly ObservableAsPropertyHelper<string> _errorMessage;
+        private readonly ObservableAsPropertyHelper<bool> _hasErrorMessage;
+        private readonly ObservableAsPropertyHelper<bool> _isBusy;
+        
         public DirectAuthViewModel(DirectAuthState state, IProvider provider)
         {
             this.ValidationRule(x => x.Username,
@@ -27,17 +31,21 @@ namespace Camelotia.Presentation.ViewModels
                 () => provider.DirectAuth(Username, Password),
                 this.IsValid());
             
-            Login.IsExecuting.ToPropertyEx(this, x => x.IsBusy);
+            _isBusy = Login
+                .IsExecuting
+                .ToProperty(this, x => x.IsBusy);
             
-            Login.ThrownExceptions
+            _errorMessage = Login
+                .ThrownExceptions
                 .Select(exception => exception.Message)
                 .Log(this, $"Direct auth error occured in {provider.Name}")
-                .ToPropertyEx(this, x => x.ErrorMessage);
+                .ToProperty(this, x => x.ErrorMessage);
 
-            Login.ThrownExceptions
+            _hasErrorMessage = Login
+                .ThrownExceptions
                 .Select(exception => true)
                 .Merge(Login.Select(unit => false))
-                .ToPropertyEx(this, x => x.HasErrorMessage);
+                .ToProperty(this, x => x.HasErrorMessage);
 
             Username = state.Username;
             Password = state.Password;
@@ -54,15 +62,12 @@ namespace Camelotia.Presentation.ViewModels
         [Reactive]
         public string Password { get; set; }
         
-        [ObservableAsProperty]
-        public string ErrorMessage { get; }
+        public bool IsBusy => _isBusy.Value;
 
-        [ObservableAsProperty]
-        public bool HasErrorMessage { get; }
+        public string ErrorMessage => _errorMessage.Value;
 
-        [ObservableAsProperty]
-        public bool IsBusy { get; }
-        
+        public bool HasErrorMessage => _hasErrorMessage.Value;
+
         public ReactiveCommand<Unit, Unit> Login { get; }
     }
 }

--- a/src/Camelotia.Presentation/ViewModels/DirectAuthViewModel.cs
+++ b/src/Camelotia.Presentation/ViewModels/DirectAuthViewModel.cs
@@ -40,10 +40,10 @@ namespace Camelotia.Presentation.ViewModels
                 .ToPropertyEx(this, x => x.HasErrorMessage);
 
             Username = state.Username;
+            Password = state.Password;
+
             this.WhenAnyValue(x => x.Username)
                 .Subscribe(name => state.Username = name);
-
-            Password = state.Password;
             this.WhenAnyValue(x => x.Password)
                 .Subscribe(pass => state.Password = pass);
         }

--- a/src/Camelotia.Presentation/ViewModels/FolderViewModel.cs
+++ b/src/Camelotia.Presentation/ViewModels/FolderViewModel.cs
@@ -16,7 +16,7 @@ namespace Camelotia.Presentation.ViewModels
         {
             Provider = provider;
             _folder = folder;
-            Children = (folder.Children != null && folder.Children.Any())
+            Children = folder.Children != null && folder.Children.Any()
                 ? folder.Children.Select(f => new FolderViewModel(provider, f))
                 : Enumerable.Empty<IFolderViewModel>();
         }

--- a/src/Camelotia.Presentation/ViewModels/FolderViewModel.cs
+++ b/src/Camelotia.Presentation/ViewModels/FolderViewModel.cs
@@ -31,7 +31,7 @@ namespace Camelotia.Presentation.ViewModels
 
         public override bool Equals(object obj)
         {
-            return (obj is FolderViewModel other) &&
+            return obj is FolderViewModel other &&
                 Equals(_folder.Name, other._folder.Name) &&
                 Equals(_folder.FullPath, other._folder.FullPath) &&
                 Equals(Provider, other.Provider);
@@ -41,7 +41,7 @@ namespace Camelotia.Presentation.ViewModels
         {
             unchecked
             {
-                int hashCode = _folder.Name.GetHashCode();
+                var hashCode = _folder.Name.GetHashCode();
                 hashCode = (hashCode * 397) ^ _folder.FullPath.GetHashCode();
                 hashCode = (hashCode * 397) ^ Provider.GetHashCode();
                 return hashCode;

--- a/src/Camelotia.Presentation/ViewModels/HostAuthViewModel.cs
+++ b/src/Camelotia.Presentation/ViewModels/HostAuthViewModel.cs
@@ -1,6 +1,5 @@
 using System.Reactive;
 using System.Reactive.Linq;
-using System.Windows.Input;
 using System;
 using Camelotia.Presentation.AppState;
 using Camelotia.Presentation.Interfaces;
@@ -14,8 +13,6 @@ namespace Camelotia.Presentation.ViewModels
 {
     public sealed class HostAuthViewModel : ReactiveValidationObject<HostAuthViewModel>, IHostAuthViewModel
     {
-        private readonly ReactiveCommand<Unit, Unit> _login;
-        
         public HostAuthViewModel(HostAuthState state, IProvider provider)
         {
             this.ValidationRule(x => x.Username,
@@ -34,20 +31,20 @@ namespace Camelotia.Presentation.ViewModels
                 port => int.TryParse(port, out _),
                 "Port should be a valid integer.");
             
-            _login = ReactiveCommand.CreateFromTask(
+            Login = ReactiveCommand.CreateFromTask(
                 () => provider.HostAuth(Address, int.Parse(Port), Username, Password),
                 this.IsValid());
 
-            _login.IsExecuting.ToPropertyEx(this, x => x.IsBusy);
+            Login.IsExecuting.ToPropertyEx(this, x => x.IsBusy);
             
-            _login.ThrownExceptions
+            Login.ThrownExceptions
                 .Select(exception => exception.Message)
                 .Log(this, $"Host auth error occured in {provider.Name}")
                 .ToPropertyEx(this, x => x.ErrorMessage);
 
-            _login.ThrownExceptions
+            Login.ThrownExceptions
                 .Select(exception => true)
-                .Merge(_login.Select(unit => false))
+                .Merge(Login.Select(unit => false))
                 .ToPropertyEx(this, x => x.HasErrorMessage);
 
             Username = state.Username;
@@ -88,6 +85,6 @@ namespace Camelotia.Presentation.ViewModels
         [ObservableAsProperty]
         public bool IsBusy { get; }
         
-        public ICommand Login => _login;
+        public ReactiveCommand<Unit, Unit> Login { get; }
     }
 }

--- a/src/Camelotia.Presentation/ViewModels/HostAuthViewModel.cs
+++ b/src/Camelotia.Presentation/ViewModels/HostAuthViewModel.cs
@@ -48,18 +48,16 @@ namespace Camelotia.Presentation.ViewModels
                 .ToPropertyEx(this, x => x.HasErrorMessage);
 
             Username = state.Username;
+            Password = state.Password;
+            Address = state.Address;
+            Port = state.Port;
+
             this.WhenAnyValue(x => x.Username)
                 .Subscribe(name => state.Username = name);
-            
-            Password = state.Password;
             this.WhenAnyValue(x => x.Password)
                 .Subscribe(name => state.Password = name);
-            
-            Address = state.Address;
             this.WhenAnyValue(x => x.Address)
                 .Subscribe(name => state.Address = name);
-            
-            Port = state.Port;
             this.WhenAnyValue(x => x.Port)
                 .Subscribe(name => state.Port = name);
         }

--- a/src/Camelotia.Presentation/ViewModels/OAuthViewModel.cs
+++ b/src/Camelotia.Presentation/ViewModels/OAuthViewModel.cs
@@ -1,6 +1,5 @@
 using System.Reactive;
 using System.Reactive.Linq;
-using System.Windows.Input;
 using Camelotia.Presentation.Interfaces;
 using Camelotia.Services.Interfaces;
 using ReactiveUI;
@@ -10,21 +9,19 @@ namespace Camelotia.Presentation.ViewModels
 {
     public sealed class OAuthViewModel : ReactiveObject, IOAuthViewModel
     {
-        private readonly ReactiveCommand<Unit, Unit> _login;
-        
         public OAuthViewModel(IProvider provider)
         {
-            _login = ReactiveCommand.CreateFromTask(provider.OAuth);
-            _login.IsExecuting.ToPropertyEx(this, x => x.IsBusy);
+            Login = ReactiveCommand.CreateFromTask(provider.OAuth);
+            Login.IsExecuting.ToPropertyEx(this, x => x.IsBusy);
 
-            _login.ThrownExceptions
+            Login.ThrownExceptions
                 .Select(exception => exception.Message)
                 .Log(this, $"OAuth error occured in {provider.Name}")
                 .ToPropertyEx(this, x => x.ErrorMessage);
 
-            _login.ThrownExceptions
+            Login.ThrownExceptions
                 .Select(exception => true)
-                .Merge(_login.Select(unit => false))
+                .Merge(Login.Select(unit => false))
                 .ToPropertyEx(this, x => x.HasErrorMessage);
         }
         
@@ -37,6 +34,6 @@ namespace Camelotia.Presentation.ViewModels
         [ObservableAsProperty]
         public bool IsBusy { get; }
         
-        public ICommand Login => _login;
+        public ReactiveCommand<Unit, Unit> Login { get; }
     }
 }

--- a/src/Camelotia.Presentation/ViewModels/ProviderViewModel.cs
+++ b/src/Camelotia.Presentation/ViewModels/ProviderViewModel.cs
@@ -107,6 +107,10 @@ namespace Camelotia.Presentation.ViewModels
                 .ObserveOn(RxApp.MainThreadScheduler)                
                 .ToPropertyEx(this, x => x.ShowBreadCrumbs);
 
+            this.WhenAnyValue(x => x.ShowBreadCrumbs)
+                .Select(show => !show)
+                .ToPropertyEx(this, x => x.HideBreadCrumbs);
+
             this.WhenAnyValue(x => x.CurrentPath, x => x.IsReady)
                 .Where(x => x.Item1 != null && x.Item2)
                 .Select(_ => Unit.Default)                
@@ -266,6 +270,9 @@ namespace Camelotia.Presentation.ViewModels
 
         [ObservableAsProperty]
         public bool ShowBreadCrumbs { get; }
+        
+        [ObservableAsProperty]
+        public bool HideBreadCrumbs { get; }
 
         [ObservableAsProperty]
         public string CurrentPath { get; }

--- a/src/Camelotia.Presentation/ViewModels/RenameFileViewModel.cs
+++ b/src/Camelotia.Presentation/ViewModels/RenameFileViewModel.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Reactive;
 using System.Reactive.Linq;
-using System.Windows.Input;
 using Camelotia.Presentation.AppState;
 using Camelotia.Presentation.Interfaces;
 using Camelotia.Services.Interfaces;
@@ -16,13 +15,10 @@ namespace Camelotia.Presentation.ViewModels
 
     public sealed class RenameFileViewModel : ReactiveValidationObject<RenameFileViewModel>, IRenameFileViewModel
     {
-        private readonly ReactiveCommand<Unit, Unit> _rename;
-        private readonly ReactiveCommand<Unit, bool> _close;
-        private readonly ReactiveCommand<Unit, bool> _open;
-        
         public RenameFileViewModel(RenameFileState state, IProviderViewModel owner, IProvider provider)
         {
-            owner.WhenAnyValue(x => x.SelectedFile.Name).ToPropertyEx(this, x => x.OldName);
+            owner.WhenAnyValue(x => x.SelectedFile.Name)
+                 .ToPropertyEx(this, x => x.OldName);
             
             this.ValidationRule(x => x.NewName,
                 name => !string.IsNullOrWhiteSpace(name),
@@ -32,11 +28,11 @@ namespace Camelotia.Presentation.ViewModels
                 name => !string.IsNullOrWhiteSpace(name),
                 "Old name shouldn't be empty.");
             
-            _rename = ReactiveCommand.CreateFromTask(
+            Rename = ReactiveCommand.CreateFromTask(
                 () => provider.RenameFile(owner.SelectedFile.Path, NewName),
                 this.IsValid());
             
-            _rename.IsExecuting.ToPropertyEx(this, x => x.IsLoading);
+            Rename.IsExecuting.ToPropertyEx(this, x => x.IsLoading);
 
             var canInteract = owner
                 .WhenAnyValue(x => x.CanInteract)
@@ -55,23 +51,25 @@ namespace Camelotia.Presentation.ViewModels
                 .WhenAnyValue(x => x.IsVisible)
                 .Select(visible => visible);
             
-            _open = ReactiveCommand.Create(() => true, canOpen);
-            _close = ReactiveCommand.Create(() => false, canClose);
+            Open = ReactiveCommand.Create(() => {}, canOpen);
+            Close = ReactiveCommand.Create(() => {}, canClose);
             
-            _close.Merge(_open).Subscribe(visible => IsVisible = visible);
-            _close.Subscribe(x => NewName = string.Empty);
-
-            _rename.InvokeCommand(_close);
+            Open.Select(unit => true)
+                .Merge(Close.Select(unit => false))
+                .Subscribe(visible => IsVisible = visible);
             
-            _rename.ThrownExceptions
+            Close.Subscribe(x => NewName = string.Empty);
+            Rename.InvokeCommand(Close);
+            
+            Rename.ThrownExceptions
                 .Select(exception => true)
-                .Merge(_close.Select(x => false))
+                .Merge(Close.Select(x => false))
                 .ToPropertyEx(this, x => x.HasErrorMessage);
 
-            _rename.ThrownExceptions
+            Rename.ThrownExceptions
                 .Select(exception => exception.Message)
                 .Log(this, $"Rename file error occured in {provider.Name} for {OldName}")
-                .Merge(_close.Select(x => string.Empty))
+                .Merge(Close.Select(x => string.Empty))
                 .ToPropertyEx(this, x => x.ErrorMessage);
 
             NewName = state.NewName;
@@ -97,10 +95,10 @@ namespace Camelotia.Presentation.ViewModels
         [ObservableAsProperty]
         public string OldName { get; }
 
-        public ICommand Rename => _rename;
+        public ReactiveCommand<Unit, Unit> Rename { get; }
 
-        public ICommand Close => _close;
+        public ReactiveCommand<Unit, Unit> Close { get; }
 
-        public ICommand Open => _open;
+        public ReactiveCommand<Unit, Unit> Open { get; }
     }
 }

--- a/src/Camelotia.Services/Providers/GoogleDriveProvider.cs
+++ b/src/Camelotia.Services/Providers/GoogleDriveProvider.cs
@@ -27,26 +27,25 @@ namespace Camelotia.Services.Providers
         
         private readonly ISubject<bool> _isAuthorized = new ReplaySubject<bool>(1);
         private readonly IBlobCache _blobCache;
-        private readonly ProviderParameters _model;
         private DriveService _driveService;
         
         public GoogleDriveProvider(ProviderParameters model, IBlobCache blobCache)
         {
-            _model = model;
+            Parameters = model;
             _blobCache = blobCache;
             _isAuthorized.OnNext(false);
             EnsureLoggedInIfTokenSaved();
         }
 
-        public ProviderParameters Parameters => _model;
+        public ProviderParameters Parameters { get; }
 
         public long? Size => null;
 
-        public Guid Id => _model.Id;
+        public Guid Id => Parameters.Id;
 
-        public string Name => _model.Type.ToString();
+        public string Name => Parameters.Type.ToString();
 
-        public DateTime Created => _model.Created;
+        public DateTime Created => Parameters.Created;
 
         public string InitialPath => "/";
 

--- a/src/Camelotia.Services/Providers/LocalProvider.cs
+++ b/src/Camelotia.Services/Providers/LocalProvider.cs
@@ -11,17 +11,15 @@ namespace Camelotia.Services.Providers
 {
     public sealed class LocalProvider : IProvider
     {
-        private readonly ProviderParameters _model;
+        public LocalProvider(ProviderParameters model) => Parameters = model;
 
-        public LocalProvider(ProviderParameters model) => _model = model;
+        public ProviderParameters Parameters { get; }
 
-        public ProviderParameters Parameters => _model;
+        public Guid Id => Parameters.Id;
 
-        public Guid Id => _model.Id;
+        public string Name => Parameters.Type.ToString();
 
-        public string Name => _model.Type.ToString();
-
-        public DateTime Created => _model.Created;
+        public DateTime Created => Parameters.Created;
 
         public long? Size => GetSizeOnAllDisks();
 
@@ -93,11 +91,9 @@ namespace Camelotia.Services.Providers
         {
             if (IsDirectory(from)) throw new InvalidOperationException("Can't download directory.");
 
-            using (var fileStream = File.OpenRead(from))
-            {
-                fileStream.Seek(0, SeekOrigin.Begin);
-                await fileStream.CopyToAsync(to);
-            }
+            using var fileStream = File.OpenRead(@from);
+            fileStream.Seek(0, SeekOrigin.Begin);
+            await fileStream.CopyToAsync(to);
         }
 
         public Task CreateFolder(string at, string name) => Task.Run(() =>
@@ -121,11 +117,9 @@ namespace Camelotia.Services.Providers
             if (!IsDirectory(to)) throw new InvalidOperationException("Can't upload to a non-directory.");
 
             var path = Path.Combine(to, name);
-            using (var fileStream = File.Create(path))
-            {
-                from.Seek(0, SeekOrigin.Begin);
-                await from.CopyToAsync(fileStream);
-            }
+            using var fileStream = File.Create(path);
+            from.Seek(0, SeekOrigin.Begin);
+            await from.CopyToAsync(fileStream);
         }
 
         public Task Delete(string path, bool isFolder) => Task.Run(() =>

--- a/src/Camelotia.Services/Providers/SftpProvider.cs
+++ b/src/Camelotia.Services/Providers/SftpProvider.cs
@@ -12,7 +12,7 @@ namespace Camelotia.Services.Providers
 {
     public sealed class SftpProvider : IProvider
     {
-        private static readonly string[] pathSeparators = { "\\", "/" };
+        private static readonly string[] PathSeparators = { "\\", "/" };
 
         private readonly ISubject<bool> _isAuthorized = new ReplaySubject<bool>();
         private Func<SftpClient> _factory;
@@ -97,13 +97,13 @@ namespace Camelotia.Services.Providers
         public Task<IEnumerable<FolderModel>> GetBreadCrumbs(string path) => Task.Run(() =>
         {
             var pathParts = new List<string> { "/" }; //Add root path first
-            pathParts.AddRange(path.Split(pathSeparators, StringSplitOptions.RemoveEmptyEntries));
+            pathParts.AddRange(path.Split(PathSeparators, StringSplitOptions.RemoveEmptyEntries));
             var foldermodels = new List<FolderModel>();
             using var connection = _factory();
             connection.Connect();
             for (var i = 0; i < pathParts.Count; i++)
             {
-                var fullPath = string.Join(pathSeparators[0], pathParts.Take(i + 1));
+                var fullPath = string.Join(PathSeparators[0], pathParts.Take(i + 1));
                 var name = pathParts[i];
                 var listing = connection.ListDirectory(fullPath);
                 var folder = new FolderModel(

--- a/src/Camelotia.Tests/Presentation/CreateFolderViewModelTests.cs
+++ b/src/Camelotia.Tests/Presentation/CreateFolderViewModelTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Reactive.Concurrency;
 using Camelotia.Presentation.AppState;
@@ -38,18 +39,19 @@ namespace Camelotia.Tests.Presentation
             _provider.CanCreateFolder.Returns(true);
             
             var model = BuildCreateFolderViewModel();
-            model.Open.CanExecute(null).Should().BeTrue();
-            model.Close.CanExecute(null).Should().BeFalse();
+            model.Open.CanExecute().Should().BeTrue();
+            model.Open.CanExecute().Should().BeTrue();
+            model.Close.CanExecute().Should().BeFalse();
             model.IsVisible.Should().BeFalse();
-            model.Open.Execute(null);
+            model.Open.Execute().Subscribe();
             
-            model.Open.CanExecute(null).Should().BeFalse();
-            model.Close.CanExecute(null).Should().BeTrue();
+            model.Open.CanExecute().Should().BeFalse();
+            model.Close.CanExecute().Should().BeTrue();
             model.IsVisible.Should().BeTrue();
-            model.Close.Execute(null);
+            model.Close.Execute().Subscribe();
             
-            model.Open.CanExecute(null).Should().BeTrue();
-            model.Close.CanExecute(null).Should().BeFalse();
+            model.Open.CanExecute().Should().BeTrue();
+            model.Close.CanExecute().Should().BeFalse();
             model.IsVisible.Should().BeFalse();
         }
 
@@ -62,31 +64,31 @@ namespace Camelotia.Tests.Presentation
 
             var model = BuildCreateFolderViewModel();
             model.IsVisible.Should().BeFalse();
-            model.Close.CanExecute(null).Should().BeFalse();
-            model.Open.CanExecute(null).Should().BeTrue();
-            model.Open.Execute(null);
+            model.Close.CanExecute().Should().BeFalse();
+            model.Open.CanExecute().Should().BeTrue();
+            model.Open.Execute().Subscribe();
 
             model.IsVisible.Should().BeTrue();
-            model.Create.CanExecute(null).Should().BeFalse();
+            model.Create.CanExecute().Should().BeFalse();
             model.ErrorMessage.Should().BeNullOrEmpty();
             model.HasErrorMessage.Should().BeFalse();
             model.IsLoading.Should().BeFalse();
 
-            model.Close.CanExecute(null).Should().BeTrue();
-            model.Open.CanExecute(null).Should().BeFalse();
+            model.Close.CanExecute().Should().BeTrue();
+            model.Open.CanExecute().Should().BeFalse();
             
             model.Name = "Foo";
-            model.Create.CanExecute(null).Should().BeTrue();
-            model.Create.Execute(null);
+            model.Create.CanExecute().Should().BeTrue();
+            model.Create.Execute().Subscribe();
             
             model.IsLoading.Should().BeFalse();
-            model.Create.CanExecute(null).Should().BeFalse();
+            model.Create.CanExecute().Should().BeFalse();
             model.Name.Should().BeNullOrEmpty();
             model.Path.Should().Be(Separator);
             model.IsVisible.Should().BeFalse();
             
-            model.Close.CanExecute(null).Should().BeFalse();
-            model.Open.CanExecute(null).Should().BeTrue();
+            model.Close.CanExecute().Should().BeFalse();
+            model.Open.CanExecute().Should().BeTrue();
         }
         
         [Fact]
@@ -95,13 +97,13 @@ namespace Camelotia.Tests.Presentation
             _model.CurrentPath.Returns(Separator);
             
             var model = BuildCreateFolderViewModel();
-            model.Create.CanExecute(null).Should().BeFalse();
+            model.Create.CanExecute().Should().BeFalse();
             model.GetErrors(string.Empty).Should().HaveCount(1);
             model.GetErrors(nameof(model.Name)).Should().HaveCount(1);
             model.HasErrors.Should().BeTrue();
 
             model.Name = "Example";
-            model.Create.CanExecute(null).Should().BeTrue();
+            model.Create.CanExecute().Should().BeTrue();
             model.GetErrors(string.Empty).Should().BeEmpty();
             model.GetErrors(nameof(model.Name)).Should().BeEmpty();
             model.HasErrors.Should().BeFalse();

--- a/src/Camelotia.Tests/Presentation/DirectAuthViewModelTests.cs
+++ b/src/Camelotia.Tests/Presentation/DirectAuthViewModelTests.cs
@@ -20,10 +20,10 @@ namespace Camelotia.Tests.Presentation
         public void LoginCommandShouldStayDisabledUntilInputIsValid()
         {
             var model = BuildDirectAuthViewModel();
-            model.Login.CanExecute(null).Should().BeFalse();
+            model.Login.CanExecute().Should().BeFalse();
             model.Username = "hello";
             model.Password = "world";
-            model.Login.CanExecute(null).Should().BeTrue();
+            model.Login.CanExecute().Should().BeTrue();
         }
 
         [Fact]
@@ -36,7 +36,8 @@ namespace Camelotia.Tests.Presentation
                 
             model.Username = "hello";
             model.Password = "world";
-            model.Login.Execute(null);
+            model.Login.Execute().Subscribe(ok => { }, error => { });
+            
             model.HasErrorMessage.Should().BeTrue();
             model.ErrorMessage.Should().Be("example");
         }
@@ -51,7 +52,7 @@ namespace Camelotia.Tests.Presentation
             
             model.Username = "hello";
             model.Password = "world";
-            model.Login.Execute(null);
+            model.Login.Execute().Subscribe();
             model.IsBusy.Should().BeTrue();
         }
 
@@ -59,21 +60,21 @@ namespace Camelotia.Tests.Presentation
         public void ShouldUpdateValidationsForProperties()
         {
             var model = BuildDirectAuthViewModel();
-            model.Login.CanExecute(null).Should().BeFalse();
+            model.Login.CanExecute().Should().BeFalse();
             model.GetErrors(string.Empty).Should().HaveCount(2);
             model.GetErrors(nameof(model.Username)).Should().NotBeEmpty();
             model.GetErrors(nameof(model.Password)).Should().NotBeEmpty();
             model.HasErrors.Should().BeTrue();
 
             model.Username = "Jotaro";
-            model.Login.CanExecute(null).Should().BeFalse();
+            model.Login.CanExecute().Should().BeFalse();
             model.GetErrors(string.Empty).Should().HaveCount(1);
             model.GetErrors(nameof(model.Username)).Should().BeEmpty();
             model.GetErrors(nameof(model.Password)).Should().NotBeEmpty();
             model.HasErrors.Should().BeTrue();
 
             model.Password = "qwerty";
-            model.Login.CanExecute(null).Should().BeTrue();
+            model.Login.CanExecute().Should().BeTrue();
             model.GetErrors(string.Empty).Should().BeEmpty();
             model.GetErrors(nameof(model.Username)).Should().BeEmpty();
             model.GetErrors(nameof(model.Password)).Should().BeEmpty();

--- a/src/Camelotia.Tests/Presentation/HostAuthViewModelTests.cs
+++ b/src/Camelotia.Tests/Presentation/HostAuthViewModelTests.cs
@@ -6,6 +6,7 @@ using Camelotia.Presentation.ViewModels;
 using Camelotia.Services.Interfaces;
 using FluentAssertions;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using ReactiveUI;
 using Xunit;
 
@@ -20,12 +21,12 @@ namespace Camelotia.Tests.Presentation
         public void LoginCommandShouldStayDisabledUntilInputIsValid()
         {
             var model = BuildHostAuthViewModel();
-            model.Login.CanExecute(null).Should().BeFalse();
+            model.Login.CanExecute().Should().BeFalse();
             model.Address = "10.10.10.10";
             model.Username = "hello";
             model.Password = "world";
             model.Port = "5000";
-            model.Login.CanExecute(null).Should().BeTrue();
+            model.Login.CanExecute().Should().BeTrue();
         }
 
         [Fact]
@@ -40,7 +41,7 @@ namespace Camelotia.Tests.Presentation
             model.Username = "hello";
             model.Password = "world";
             model.Address = "10.10.10.10";
-            model.Login.Execute(null);
+            model.Login.Execute().Subscribe(ok => { }, error => { });
             
             model.HasErrorMessage.Should().BeTrue();
             model.ErrorMessage.Should().Be("example");
@@ -58,7 +59,7 @@ namespace Camelotia.Tests.Presentation
             model.Username = "hello";
             model.Password = "world";
             model.Address = "10.10.10.10";
-            model.Login.Execute(null);
+            model.Login.Execute().Subscribe();
             model.IsBusy.Should().BeTrue();
         }
 
@@ -66,26 +67,26 @@ namespace Camelotia.Tests.Presentation
         public void ShouldTreatNonIntegersAsInvalid()
         {
             var model = BuildHostAuthViewModel();
-            model.Login.CanExecute(null).Should().BeFalse();
+            model.Login.CanExecute().Should().BeFalse();
             
             model.Port = "5000";
             model.Username = "hello";
             model.Password = "world";
             model.Address = "10.10.10.10";
-            model.Login.CanExecute(null).Should().BeTrue();
+            model.Login.CanExecute().Should().BeTrue();
 
             model.Port = "abc";
-            model.Login.CanExecute(null).Should().BeFalse();
+            model.Login.CanExecute().Should().BeFalse();
             
             model.Port = "42";
-            model.Login.CanExecute(null).Should().BeTrue();
+            model.Login.CanExecute().Should().BeTrue();
         }
         
         [Fact]
         public void ShouldUpdateValidationsForProperties()
         {
             var model = BuildHostAuthViewModel();
-            model.Login.CanExecute(null).Should().BeFalse();
+            model.Login.CanExecute().Should().BeFalse();
             model.GetErrors(string.Empty).Should().HaveCount(4);
             model.GetErrors(nameof(model.Username)).Should().NotBeEmpty();
             model.GetErrors(nameof(model.Password)).Should().NotBeEmpty();
@@ -98,7 +99,7 @@ namespace Camelotia.Tests.Presentation
             model.Address = "127.0.0.1";
             model.Port = "5000";
             
-            model.Login.CanExecute(null).Should().BeTrue();
+            model.Login.CanExecute().Should().BeTrue();
             model.GetErrors(string.Empty).Should().BeEmpty();
             model.GetErrors(nameof(model.Username)).Should().BeEmpty();
             model.GetErrors(nameof(model.Password)).Should().BeEmpty();

--- a/src/Camelotia.Tests/Presentation/MainViewModelTests.cs
+++ b/src/Camelotia.Tests/Presentation/MainViewModelTests.cs
@@ -27,8 +27,8 @@ namespace Camelotia.Tests.Presentation
             model.IsLoading.Should().BeFalse();
             model.IsReady.Should().BeTrue();
                 
-            model.Refresh.CanExecute(null).Should().BeTrue();
-            model.Refresh.Execute(null);
+            model.Refresh.CanExecute().Should().BeTrue();
+            model.Refresh.Execute().Subscribe();
                 
             model.Providers.Should().BeEmpty();
             model.IsLoading.Should().BeFalse();
@@ -46,7 +46,7 @@ namespace Camelotia.Tests.Presentation
             model.Providers.Should().NotBeEmpty();
             model.SelectedProvider.Should().NotBeNull();
             model.SelectedProvider.Id.Should().Be(provider.Id);
-            model.Refresh.Execute(null);
+            model.Refresh.Execute().Subscribe();
                 
             model.Providers.Should().NotBeEmpty();
             model.SelectedProvider.Should().NotBeNull();
@@ -64,8 +64,8 @@ namespace Camelotia.Tests.Presentation
             model.Providers.Should().NotBeEmpty();
             model.SelectedProvider.Should().NotBeNull();
             model.SelectedProvider.Id.Should().Be(provider.Id);
-            model.Unselect.CanExecute(null).Should().BeTrue();
-            model.Unselect.Execute(null);
+            model.Unselect.CanExecute().Should().BeTrue();
+            model.Unselect.Execute().Subscribe();
 
             model.Providers.Should().NotBeEmpty();
             model.SelectedProvider.Should().BeNull();
@@ -102,7 +102,7 @@ namespace Camelotia.Tests.Presentation
             model.Providers.Count.Should().Be(2);
             model.SelectedProvider.Should().NotBeNull();
             model.SelectedProvider.Id.Should().Be(provider.Id);
-            model.Remove.Execute(null);
+            model.Remove.Execute().Subscribe();
 
             model.SelectedProvider.Should().BeNull();
             model.Providers.Count.Should().Be(1);
@@ -115,7 +115,7 @@ namespace Camelotia.Tests.Presentation
             model.Providers.Should().BeEmpty();
             model.SelectedProvider.Should().BeNull();
             model.SelectedSupportedType = ProviderType.Local;
-            model.Add.Execute(null);
+            model.Add.Execute().Subscribe();
 
             model.Providers.Should().NotBeEmpty();
             model.Providers.Count.Should().Be(1);

--- a/src/Camelotia.Tests/Presentation/OAuthViewModelTests.cs
+++ b/src/Camelotia.Tests/Presentation/OAuthViewModelTests.cs
@@ -21,8 +21,8 @@ namespace Camelotia.Tests.Presentation
             
             var model = BuildOAuthViewModel();
             model.IsBusy.Should().BeFalse();
-            model.Login.CanExecute(null).Should().BeTrue();
-            model.Login.Execute(null);
+            model.Login.CanExecute().Should().BeTrue();
+            model.Login.Execute().Subscribe();
             
             model.IsBusy.Should().BeTrue();
         }
@@ -36,8 +36,8 @@ namespace Camelotia.Tests.Presentation
             model.ErrorMessage.Should().BeNullOrEmpty();
             model.HasErrorMessage.Should().BeFalse();
             
-            model.Login.CanExecute(null).Should().BeTrue();
-            model.Login.Execute(null);
+            model.Login.CanExecute().Should().BeTrue();
+            model.Login.Execute().Subscribe(ok => { }, err => { });
 
             model.HasErrorMessage.Should().BeTrue();
             model.ErrorMessage.Should().NotBeNullOrEmpty();

--- a/src/Camelotia.Tests/Presentation/ProviderViewModelTests.cs
+++ b/src/Camelotia.Tests/Presentation/ProviderViewModelTests.cs
@@ -32,7 +32,7 @@ namespace Camelotia.Tests.Presentation
             model.IsLoading.Should().BeFalse();
             model.IsReady.Should().BeFalse();
                 
-            model.Refresh.Execute(null);
+            model.Refresh.Execute().Subscribe();
             model.IsReady.Should().BeTrue();
         }
 
@@ -47,7 +47,7 @@ namespace Camelotia.Tests.Presentation
             model.CurrentPath.Should().Be(Separator);
             model.Files.Should().BeNullOrEmpty();
 
-            model.Refresh.Execute(null);
+            model.Refresh.Execute().Subscribe();
             model.IsCurrentPathEmpty.Should().BeTrue();
             model.CurrentPath.Should().Be(Separator);
             model.Files.Should().BeEmpty();
@@ -76,12 +76,12 @@ namespace Camelotia.Tests.Presentation
             _provider.SupportsDirectAuth.Returns(true);
 
             var model = BuildProviderViewModel();
-            model.Logout.CanExecute(null).Should().BeTrue();
-            model.Logout.Execute(null);
+            model.Logout.CanExecute().Should().BeTrue();
+            model.Logout.Execute().Subscribe();
             
             authorized.OnNext(false);
             _provider.Received(1).Logout();
-            model.Logout.CanExecute(null).Should().BeFalse();            
+            model.Logout.CanExecute().Should().BeFalse();            
         }
 
         [Fact]
@@ -99,12 +99,12 @@ namespace Camelotia.Tests.Presentation
                 model.CurrentPath.Should().Be(Separator);
                 
                 model.SelectedFile = model.Files.First();
-                model.Open.CanExecute(null).Should().BeTrue();
-                model.Open.Execute(null);
+                model.Open.CanExecute().Should().BeTrue();
+                model.Open.Execute().Subscribe();
                 
                 model.CurrentPath.Should().Be(Separator + "foo");
-                model.Back.CanExecute(null).Should().BeTrue();
-                model.Back.Execute(null);
+                model.Back.CanExecute().Should().BeTrue();
+                model.Back.Execute().Subscribe();
                 
                 model.CurrentPath.Should().Be(Separator);
             }
@@ -119,8 +119,8 @@ namespace Camelotia.Tests.Presentation
 
             var model = BuildProviderViewModel();
             model.CurrentPath.Should().Be(Separator);
-            model.UploadToCurrentPath.CanExecute(null).Should().BeTrue();
-            model.UploadToCurrentPath.Execute(null);
+            model.UploadToCurrentPath.CanExecute().Should().BeTrue();
+            model.UploadToCurrentPath.Execute().Subscribe();
             _provider.Received(1).Get(Separator);
         }
 
@@ -133,19 +133,19 @@ namespace Camelotia.Tests.Presentation
             _provider.InitialPath.Returns(Separator);
 
             var model = BuildProviderViewModel();
-            model.Refresh.Execute(null);
+            model.Refresh.Execute().Subscribe();
 
             model.Files.Should().NotBeEmpty();
             model.CurrentPath.Should().Be(Separator);
 
             model.SelectedFile = model.Files.First();
             model.SelectedFile.Should().NotBeNull();
-            model.Open.CanExecute(null).Should().BeTrue();
-            model.Open.Execute(null);
+            model.Open.CanExecute().Should().BeTrue();
+            model.Open.Execute().Subscribe();
 
             model.CurrentPath.Should().Be(Separator + "foo");
             model.SelectedFile.Should().BeNull();
-            model.Open.CanExecute(null).Should().BeFalse();
+            model.Open.CanExecute().Should().BeFalse();
         }
 
         [Fact]
@@ -157,11 +157,11 @@ namespace Camelotia.Tests.Presentation
             _provider.InitialPath.Returns(Separator);
 
             var model = BuildProviderViewModel();
-            model.Refresh.Execute(null);
+            model.Refresh.Execute().Subscribe();
             
             model.Files.Should().NotBeEmpty();
             model.CurrentPath.Should().Be(Separator);
-            model.Back.Execute(null);
+            model.Back.Execute().Subscribe();
 
             model.CurrentPath.Should().Be(Separator);
         }
@@ -174,10 +174,10 @@ namespace Camelotia.Tests.Presentation
 
             var model = BuildProviderViewModel();
             model.CurrentPath.Should().Be(initial);
-            model.Refresh.Execute(null);
+            model.Refresh.Execute().Subscribe();
 
             model.CurrentPath.Should().Be(initial);
-            model.Back.Execute(null);
+            model.Back.Execute().Subscribe();
 
             model.CurrentPath.Should().Be(Separator);
             _state.CurrentPath.Should().Be(Separator);
@@ -225,7 +225,7 @@ namespace Camelotia.Tests.Presentation
 
             model.ShowBreadCrumbs.Should().BeFalse();
             model.BreadCrumbs.Should().BeNullOrEmpty();            
-            model.Refresh.Execute(null);
+            model.Refresh.Execute().Subscribe();
             
             model.ShowBreadCrumbs.Should().BeTrue();
             model.BreadCrumbs.Should().NotBeNullOrEmpty();

--- a/src/Camelotia.Tests/Presentation/ProviderViewModelTests.cs
+++ b/src/Camelotia.Tests/Presentation/ProviderViewModelTests.cs
@@ -211,6 +211,7 @@ namespace Camelotia.Tests.Presentation
 
             var model = BuildProviderViewModel();
             model.ShowBreadCrumbs.Should().BeFalse();
+            model.HideBreadCrumbs.Should().BeTrue();
             model.BreadCrumbs.Should().BeNullOrEmpty();            
         }
 
@@ -224,10 +225,12 @@ namespace Camelotia.Tests.Presentation
             var model = BuildProviderViewModel();
 
             model.ShowBreadCrumbs.Should().BeFalse();
+            model.HideBreadCrumbs.Should().BeTrue();
             model.BreadCrumbs.Should().BeNullOrEmpty();            
             model.Refresh.Execute().Subscribe();
             
             model.ShowBreadCrumbs.Should().BeTrue();
+            model.HideBreadCrumbs.Should().BeFalse();
             model.BreadCrumbs.Should().NotBeNullOrEmpty();
             model.BreadCrumbs.Should().HaveCount(1);
         }

--- a/src/Camelotia.Tests/Presentation/RenameFileViewModelTests.cs
+++ b/src/Camelotia.Tests/Presentation/RenameFileViewModelTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Reactive.Concurrency;
 using Camelotia.Presentation.AppState;
 using Camelotia.Presentation.Interfaces;
@@ -37,18 +38,18 @@ namespace Camelotia.Tests.Presentation
             _file.Name.Returns("foo");
 
             var model = BuildRenameFileViewModel();
-            model.Open.CanExecute(null).Should().BeTrue();
-            model.Close.CanExecute(null).Should().BeFalse();
+            model.Open.CanExecute().Should().BeTrue();
+            model.Close.CanExecute().Should().BeFalse();
             model.IsVisible.Should().BeFalse();
             
-            model.Open.Execute(null);
-            model.Open.CanExecute(null).Should().BeFalse();
-            model.Close.CanExecute(null).Should().BeTrue();
+            model.Open.Execute().Subscribe();
+            model.Open.CanExecute().Should().BeFalse();
+            model.Close.CanExecute().Should().BeTrue();
             model.IsVisible.Should().BeTrue();
 
-            model.Close.Execute(null);
-            model.Open.CanExecute(null).Should().BeTrue();
-            model.Close.CanExecute(null).Should().BeFalse();
+            model.Close.Execute().Subscribe();
+            model.Open.CanExecute().Should().BeTrue();
+            model.Close.CanExecute().Should().BeFalse();
             model.IsVisible.Should().BeFalse();
         }
 
@@ -62,31 +63,31 @@ namespace Camelotia.Tests.Presentation
             var model = BuildRenameFileViewModel();
             model.OldName.Should().Be("foo");
             model.IsVisible.Should().BeFalse();
-            model.Close.CanExecute(null).Should().BeFalse();
-            model.Open.CanExecute(null).Should().BeTrue();
+            model.Close.CanExecute().Should().BeFalse();
+            model.Open.CanExecute().Should().BeTrue();
 
-            model.Open.Execute(null);
+            model.Open.Execute().Subscribe();
             model.IsVisible.Should().BeTrue();
-            model.Rename.CanExecute(null).Should().BeFalse();
+            model.Rename.CanExecute().Should().BeFalse();
             model.ErrorMessage.Should().BeNullOrEmpty();
             model.HasErrorMessage.Should().BeFalse();
             model.IsLoading.Should().BeFalse();
 
-            model.Close.CanExecute(null).Should().BeTrue();
-            model.Open.CanExecute(null).Should().BeFalse();
+            model.Close.CanExecute().Should().BeTrue();
+            model.Open.CanExecute().Should().BeFalse();
             
             model.NewName = "Foo";
-            model.Rename.CanExecute(null).Should().BeTrue();
-            model.Rename.Execute(null);
+            model.Rename.CanExecute().Should().BeTrue();
+            model.Rename.Execute().Subscribe();
             
             model.IsLoading.Should().BeFalse();
-            model.Rename.CanExecute(null).Should().BeFalse();
+            model.Rename.CanExecute().Should().BeFalse();
             model.NewName.Should().BeNullOrEmpty();
             model.OldName.Should().Be("foo");
             model.IsVisible.Should().BeFalse();
             
-            model.Close.CanExecute(null).Should().BeFalse();
-            model.Open.CanExecute(null).Should().BeTrue();
+            model.Close.CanExecute().Should().BeFalse();
+            model.Open.CanExecute().Should().BeTrue();
         }
         
         [Fact]
@@ -96,13 +97,13 @@ namespace Camelotia.Tests.Presentation
             _file.Name.Returns("foo");
             
             var model = BuildRenameFileViewModel();
-            model.Rename.CanExecute(null).Should().BeFalse();
+            model.Rename.CanExecute().Should().BeFalse();
             model.GetErrors(string.Empty).Should().HaveCount(1);
             model.GetErrors(nameof(model.NewName)).Should().HaveCount(1);
             model.HasErrors.Should().BeTrue();
 
             model.NewName = "bar";
-            model.Rename.CanExecute(null).Should().BeTrue();
+            model.Rename.CanExecute().Should().BeTrue();
             model.GetErrors(string.Empty).Should().BeEmpty();
             model.GetErrors(nameof(model.NewName)).Should().BeEmpty();
             model.HasErrors.Should().BeFalse();

--- a/src/Camelotia.Tests/TestingExtensions.cs
+++ b/src/Camelotia.Tests/TestingExtensions.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Reactive.Linq;
+using ReactiveUI;
+
+namespace Camelotia.Tests
+{
+    public static class TestingExtensions
+    {
+        public static bool CanExecute(this IReactiveCommand command)
+        {
+            var canExecute = false;
+            command.CanExecute.Take(1).Subscribe(value => canExecute = value);
+            return canExecute;
+        }
+    }
+}


### PR DESCRIPTION
According to https://www.reactiveui.net/docs/handbook/commands/#unit-testing we never mock a reactive command, so not much sense in exposing a `ICommand` instead of a more specific type. Also, `ReactiveCommand` exposes a bunch of observables that might be useful if we decide to port the app to e.g. `Terminal.Gui` etc. Additionally, this PR enhances formatting and stuff. Also use `ObservableAsPropertyHelper<T>` classes explicitly due to compile-time property checks.