### PR TITLE
feature: Use Roslyn to generate x:Name refs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,9 +18,6 @@ jobs:
   variables:
     buildConfiguration: 'Release'
   steps:
-  - task: DotNetCoreInstaller@0
-    inputs:
-      version: '3.1.302'
   - script: cd $(Build.SourcesDirectory) && powershell -ExecutionPolicy Unrestricted ./build.ps1 --full
     displayName: 'Windows Full Build and Tests'
   - task: PublishTestResults@2

--- a/src/Camelotia.Presentation.Avalonia/Camelotia.Presentation.Avalonia.csproj
+++ b/src/Camelotia.Presentation.Avalonia/Camelotia.Presentation.Avalonia.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Avalonia.Desktop" Version="0.9.12" />
     <PackageReference Include="Avalonia.ReactiveUI" Version="0.9.12" />
     <PackageReference Include="Citrus.Avalonia" Version="1.2.6" />
+    <PackageReference Include="XamlNameReferenceGenerator" Version="0.2.1-preview" />
   </ItemGroup>
 
   <ItemGroup>
@@ -30,6 +31,7 @@
     <EmbeddedResource Include="**\*.xaml">
       <SubType>Designer</SubType>
     </EmbeddedResource>
+    <AdditionalFiles Include="**\*.xaml" />
   </ItemGroup>
 
 </Project>

--- a/src/Camelotia.Presentation.Avalonia/Views/AuthView.xaml.cs
+++ b/src/Camelotia.Presentation.Avalonia/Views/AuthView.xaml.cs
@@ -9,29 +9,28 @@ using ReactiveUI;
 
 namespace Camelotia.Presentation.Avalonia.Views
 {
-    public sealed class AuthView : ReactiveUserControl<IAuthViewModel>
+    public sealed partial class AuthView : ReactiveUserControl<IAuthViewModel>
     {
         public AuthView()
         {
+            AvaloniaXamlLoader.Load(this);
             this.WhenActivated(disposables =>
             {
-                var tabs = this.FindControl<Carousel>("AuthTabs");
                 this.WhenAnyValue(x => x.ViewModel.SupportsDirectAuth)
                     .Where(supports => supports)
-                    .Subscribe(supports => tabs.SelectedIndex = 0)
+                    .Subscribe(supports => AuthTabs.SelectedIndex = 0)
                     .DisposeWith(disposables);
 
                 this.WhenAnyValue(x => x.ViewModel.SupportsOAuth)
                     .Where(supports => supports)
-                    .Subscribe(supports => tabs.SelectedIndex = 1)
+                    .Subscribe(supports => AuthTabs.SelectedIndex = 1)
                     .DisposeWith(disposables);
 
                 this.WhenAnyValue(x => x.ViewModel.SupportsHostAuth)
                     .Where(supports => supports)
-                    .Subscribe(supports => tabs.SelectedIndex = 2)
+                    .Subscribe(supports => AuthTabs.SelectedIndex = 2)
                     .DisposeWith(disposables);
             });
-            AvaloniaXamlLoader.Load(this);
         }
     }
 }

--- a/src/Camelotia.Presentation.Avalonia/Views/CreateFolderView.xaml.cs
+++ b/src/Camelotia.Presentation.Avalonia/Views/CreateFolderView.xaml.cs
@@ -5,12 +5,12 @@ using ReactiveUI;
 
 namespace Camelotia.Presentation.Avalonia.Views
 {
-    public sealed class CreateFolderView : ReactiveUserControl<ICreateFolderViewModel>
+    public sealed partial class CreateFolderView : ReactiveUserControl<ICreateFolderViewModel>
     {
         public CreateFolderView()
         {
-            this.WhenActivated(disposables => { });
             AvaloniaXamlLoader.Load(this);
+            this.WhenActivated(disposables => { });
         }
     }
 }

--- a/src/Camelotia.Presentation.Avalonia/Views/DirectAuthView.xaml.cs
+++ b/src/Camelotia.Presentation.Avalonia/Views/DirectAuthView.xaml.cs
@@ -5,12 +5,12 @@ using ReactiveUI;
 
 namespace Camelotia.Presentation.Avalonia.Views
 {
-    public sealed class DirectAuthView : ReactiveUserControl<IDirectAuthViewModel>
+    public sealed partial class DirectAuthView : ReactiveUserControl<IDirectAuthViewModel>
     {
         public DirectAuthView()
         {
-            this.WhenActivated(disposables => { });
             AvaloniaXamlLoader.Load(this);
+            this.WhenActivated(disposables => { });
         }
     }
 }

--- a/src/Camelotia.Presentation.Avalonia/Views/FileView.xaml.cs
+++ b/src/Camelotia.Presentation.Avalonia/Views/FileView.xaml.cs
@@ -11,7 +11,7 @@ using ReactiveUI;
 
 namespace Camelotia.Presentation.Avalonia.Views
 {
-    public sealed class FileView : ReactiveUserControl<IFileViewModel>
+    public sealed partial class FileView : ReactiveUserControl<IFileViewModel>
     {
         public FileView()
         {

--- a/src/Camelotia.Presentation.Avalonia/Views/FolderView.xaml.cs
+++ b/src/Camelotia.Presentation.Avalonia/Views/FolderView.xaml.cs
@@ -8,14 +8,8 @@ using ReactiveUI;
 
 namespace Camelotia.Presentation.Avalonia.Views
 {
-    public sealed class FolderView : ReactiveUserControl<IFolderViewModel>
+    public sealed partial class FolderView : ReactiveUserControl<IFolderViewModel>
     {
-        private MenuItem TopLevelMenu => this.FindControl<MenuItem>("TopLevelMenu");
-
-        private DrawingPresenter ArrowRight => this.FindControl<DrawingPresenter>("ArrowRight");
-
-        private DrawingPresenter ArrowDown => this.FindControl<DrawingPresenter>("ArrowDown");
-
         public FolderView()
         {
             AvaloniaXamlLoader.Load(this);

--- a/src/Camelotia.Presentation.Avalonia/Views/HostAuthView.xaml.cs
+++ b/src/Camelotia.Presentation.Avalonia/Views/HostAuthView.xaml.cs
@@ -5,12 +5,12 @@ using ReactiveUI;
 
 namespace Camelotia.Presentation.Avalonia.Views
 {
-    public sealed class HostAuthView : ReactiveUserControl<IHostAuthViewModel>
+    public sealed partial class HostAuthView : ReactiveUserControl<IHostAuthViewModel>
     {
         public HostAuthView()
         {
-            this.WhenActivated(disposables => { });
             AvaloniaXamlLoader.Load(this);
+            this.WhenActivated(disposables => { });
         }
     }
 }

--- a/src/Camelotia.Presentation.Avalonia/Views/MainView.xaml
+++ b/src/Camelotia.Presentation.Avalonia/Views/MainView.xaml
@@ -106,7 +106,7 @@
                         Content="Remove" />
                 <Button Grid.Column="1"
                         Classes="Primary"
-                        Name="SwitchThemeButton"
+                        x:Name="SwitchThemeButton"
                         HorizontalAlignment="Stretch"
                         Content="Switch Theme" />
             </Grid>

--- a/src/Camelotia.Presentation.Avalonia/Views/MainView.xaml.cs
+++ b/src/Camelotia.Presentation.Avalonia/Views/MainView.xaml.cs
@@ -1,4 +1,3 @@
-using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using Avalonia.ReactiveUI;
 using Camelotia.Presentation.Interfaces;
@@ -6,14 +5,12 @@ using ReactiveUI;
 
 namespace Camelotia.Presentation.Avalonia.Views
 {
-    public sealed class MainView : ReactiveWindow<IMainViewModel>
+    public sealed partial class MainView : ReactiveWindow<IMainViewModel>
     {
-        public Button SwitchThemeButton => this.FindControl<Button>("SwitchThemeButton");
-
         public MainView()
         {
-            this.WhenActivated(disposables => { });
             AvaloniaXamlLoader.Load(this);
+            this.WhenActivated(disposables => { });
         }
     }
 }

--- a/src/Camelotia.Presentation.Avalonia/Views/OAuthView.xaml.cs
+++ b/src/Camelotia.Presentation.Avalonia/Views/OAuthView.xaml.cs
@@ -5,12 +5,12 @@ using ReactiveUI;
 
 namespace Camelotia.Presentation.Avalonia.Views
 {
-    public sealed class OAuthView : ReactiveUserControl<IOAuthViewModel>
+    public sealed partial class OAuthView : ReactiveUserControl<IOAuthViewModel>
     {
         public OAuthView()
         {
-            this.WhenActivated(disposables => { });
             AvaloniaXamlLoader.Load(this);
+            this.WhenActivated(disposables => { });
         }
     }
 }

--- a/src/Camelotia.Presentation.Avalonia/Views/ProviderView.xaml.cs
+++ b/src/Camelotia.Presentation.Avalonia/Views/ProviderView.xaml.cs
@@ -5,12 +5,12 @@ using ReactiveUI;
 
 namespace Camelotia.Presentation.Avalonia.Views
 {
-    public sealed class ProviderView : ReactiveUserControl<ICloudViewModel>
+    public sealed partial class ProviderView : ReactiveUserControl<ICloudViewModel>
     {
         public ProviderView()
         {
-            this.WhenActivated(disposables => { });
             AvaloniaXamlLoader.Load(this);
+            this.WhenActivated(disposables => { });
         }
     }
 }

--- a/src/Camelotia.Presentation.Avalonia/Views/RenameFileView.xaml.cs
+++ b/src/Camelotia.Presentation.Avalonia/Views/RenameFileView.xaml.cs
@@ -5,12 +5,12 @@ using ReactiveUI;
 
 namespace Camelotia.Presentation.Avalonia.Views
 {
-    public sealed class RenameFileView : ReactiveUserControl<IRenameFileViewModel>
+    public sealed partial class RenameFileView : ReactiveUserControl<IRenameFileViewModel>
     {
         public RenameFileView()
         {
-            this.WhenActivated(disposables => { });
             AvaloniaXamlLoader.Load(this);
+            this.WhenActivated(disposables => { });
         }
     }
 }


### PR DESCRIPTION
This PR incorporates the [Avalonia.NameGenerator](https://github.com/avaloniaui/avalonia.namegenerator) in order to avoid calling `this.FindControl<T>` by hand. Requires .NET 5. 