### PR TITLE
Only interract with clouds once they are connected

### DIFF
--- a/src/Camelotia.Presentation/ViewModels/CloudViewModel.cs
+++ b/src/Camelotia.Presentation/ViewModels/CloudViewModel.cs
@@ -28,6 +28,7 @@ namespace Camelotia.Presentation.ViewModels
         private readonly ObservableAsPropertyHelper<bool> _hideBreadCrumbs;
         private readonly ObservableAsPropertyHelper<string> _currentPath;
         private readonly ObservableAsPropertyHelper<bool> _canInteract;
+        private readonly ObservableAsPropertyHelper<bool> _canInteractAuthenticated;
         private readonly ObservableAsPropertyHelper<bool> _isLoading;
         private readonly ObservableAsPropertyHelper<bool> _canLogout;
         private readonly ObservableAsPropertyHelper<bool> _isReady;
@@ -52,15 +53,24 @@ namespace Camelotia.Presentation.ViewModels
                 .WhenAnyValue(
                     x => x.Folder.IsVisible,
                     x => x.Rename.IsVisible,
-                    x => x.Auth.IsAuthenticated,
-                    (folder, rename, auth) => !folder && !rename && auth);
+                    (folder, rename) => !folder && !rename);
 
             _canInteract = canInteract
                 .ToProperty(this, x => x.CanInteract);
 
+            var canInteractAuthenticated = this
+                .WhenAnyValue(
+                    x => x.Folder.IsVisible,
+                    x => x.Rename.IsVisible,
+                    x => x.Auth.IsAuthenticated,
+                    (folder, rename, auth) => !folder && !rename && auth);
+
+            _canInteractAuthenticated = canInteractAuthenticated
+                .ToProperty(this, x => x.CanInteractAuthenticated);
+
             Refresh = ReactiveCommand.CreateFromTask(
                 () => cloud.GetFiles(CurrentPath),
-                canInteract);
+                canInteractAuthenticated);
 
             _files = Refresh
                 .Select(
@@ -270,6 +280,8 @@ namespace Camelotia.Presentation.ViewModels
         public bool IsReady => _isReady.Value;
 
         public bool CanInteract => _canInteract?.Value ?? false;
+
+        public bool CanInteractAuthenticated => _canInteractAuthenticated?.Value ?? false;
 
         public IAuthViewModel Auth { get; }
 

--- a/src/Camelotia.Presentation/ViewModels/CloudViewModel.cs
+++ b/src/Camelotia.Presentation/ViewModels/CloudViewModel.cs
@@ -52,7 +52,8 @@ namespace Camelotia.Presentation.ViewModels
                 .WhenAnyValue(
                     x => x.Folder.IsVisible,
                     x => x.Rename.IsVisible,
-                    (folder, rename) => !folder && !rename);
+                    x => x.Auth.IsAuthenticated,
+                    (folder, rename, auth) => !folder && !rename && auth);
 
             _canInteract = canInteract
                 .ToProperty(this, x => x.CanInteract);


### PR DESCRIPTION
If you add an empty FTP or SFTP entry without setting up authentication the frontend will crash with NullPointerException once it tries to get a list of files. This simply makes CloudViewModel._canInteract also consider CloudViewModel.Auth.IsAuthenticated.